### PR TITLE
Changed how titles are colored in chat

### DIFF
--- a/Player/Player.cs
+++ b/Player/Player.cs
@@ -1305,7 +1305,7 @@ namespace MCGalaxy {
 
         public void SetPrefix() { 
             string viptitle = isDev ? string.Format("{1}[{0}Dev{1}] ", c.Parse("blue"), color) : isMod ? string.Format("{1}[{0}Mod{1}] ", c.Parse("lime"), color) : isGCMod ? string.Format("{1}[{0}GCMod{1}] ", c.Parse("gold"), color) : "";
-            prefix = ( title == "" ) ? "" : ( titlecolor == "" ) ? color + "[" + title + "] " : color + "[" + titlecolor + title + color + "] ";
+            prefix = ( title == "" ) ? "" : ( titlecolor == "" ) ? color + "[" + title + color + "] " : titlecolor + "[" + titlecolor + title + titlecolor + "] " + color;
             prefix = viptitle + prefix;
         }
 


### PR DESCRIPTION
Updated code so both brackets will take on the color of /tcolor when active. 
If no tcolor is active, they will use the player's color. If color codes are used in the title, the brackets will use either the active /tcolor or whatever /color the player has. Color codes in nicknames will not effect bracket color.

Example:
http://i.imgur.com/cdCtMMz.png
