### PR TITLE
Temporary MCGalaxy-protection-level fix

### DIFF
--- a/GUI/PropertyWindow.cs
+++ b/GUI/PropertyWindow.cs
@@ -141,6 +141,7 @@ namespace MCGalaxy.Gui {
             comboBoxProtection.Items.Add("Off");
             comboBoxProtection.Items.Add("Dev");
             comboBoxProtection.Items.Add("Mod");
+            comboBoxProtection.SelectedIndex = comboBoxProtection.Items.Count - 3;
 
             //Load server stuff
             LoadProp("properties/server.properties");


### PR DESCRIPTION
Made MCGalaxy-protection-level comboBox automatically select the option "Off". This is a temporary fix as doing this will not allow the owner to change this option in the PropertyWindow when Applying or Saving server properties. However this does fix the issue with server.properties failing to successfully save/update within the GUI.
