### PR TITLE
Modified /Goto and Removed GC Banlist Updating

### DIFF
--- a/Commands/CmdGcbanlistupdate.cs
+++ b/Commands/CmdGcbanlistupdate.cs
@@ -14,7 +14,7 @@
 	BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 	or implied. See the Licenses for the specific language governing
 	permissions and limitations under the Licenses.
-*/
+
 namespace MCGalaxy.Commands
 {
     public sealed class CmdGcbanlistupdate : Command
@@ -34,4 +34,4 @@ namespace MCGalaxy.Commands
             Player.SendMessage(p, "/gcbanlistupdate - Updates the global chat ban list for this server.");
         }
     }
-}
+}*/

--- a/Commands/CmdSpin.cs
+++ b/Commands/CmdSpin.cs
@@ -38,6 +38,7 @@ namespace MCGalaxy.Commands
 
             switch (message)
             {
+                case "90":
                 case "y":
                     p.CopyBuffer.ForEach(delegate(Player.CopyPos Pos)
                     {

--- a/Commands/Command.cs
+++ b/Commands/Command.cs
@@ -120,7 +120,7 @@ namespace MCGalaxy
 			all.Add(new CmdGcaccept());
             all.Add(new CmdGcmods());
 			all.Add(new CmdGcrules());
-			all.Add(new CmdGcbanlistupdate());
+			//all.Add(new CmdGcbanlistupdate());
 			all.Add(new CmdGive());
 			all.Add(new CmdGlobal());
 			all.Add(new CmdGlobalCLS());

--- a/GlobalChatBot.cs
+++ b/GlobalChatBot.cs
@@ -246,11 +246,11 @@ namespace MCGalaxy
             RemoveVariables(ref message);
             RemoveWhitespace(ref message);
 
-            if (message.Contains("^UGCS"))
-            {
-                Server.UpdateGlobalSettings();
-                return;
-            }
+            //if (message.Contains("^UGCS"))
+            //{
+            //    Server.UpdateGlobalSettings();
+            //    return;
+            //}
             if (message.Contains("^IPGET "))
             {
                 foreach (Player p in Player.players)

--- a/Levels/Level.cs
+++ b/Levels/Level.cs
@@ -522,7 +522,7 @@ namespace MCGalaxy
             foreach (Level level in Server.levels)
             {
                 if (level.name.ToLower() == levelName) return level;
-                if (level.name.ToLower().IndexOf(levelName.ToLower(), System.StringComparison.Ordinal) == -1) continue;
+                else { continue; }
                 if (tempLevel == null) tempLevel = level;
                 else returnNull = true;
             }

--- a/Player/Player.cs
+++ b/Player/Player.cs
@@ -379,10 +379,10 @@ namespace MCGalaxy {
                 socket = s;
                 ip = socket.RemoteEndPoint.ToString().Split(':')[0];
 
-                if (IPInPrivateRange(ip))
+                /*if (IPInPrivateRange(ip))
                     exIP = ResolveExternalIP(ip);
                 else
-                    exIP = ip;
+                    exIP = ip;*/
 
                 Server.s.Log(ip + " connected to the server.");
 
@@ -4425,14 +4425,14 @@ Next: continue;
             //return IsLocalIpAddress(ip);
         }
 
-        public string ResolveExternalIP(string ip) {
+        /*public string ResolveExternalIP(string ip) {
             HTTPGet req = new HTTPGet();
             req.Request("http://checkip.dyndns.org");
             string[] a1 = req.ResponseBody.Split(':');
             string a2 = a1[1].Substring(1);
             string[] a3 = a2.Split('<');
             return a3[0];
-        }
+        }*/
 
         public static bool IsLocalIpAddress(string host) {
             try { // get host IP addresses

--- a/Server.cs
+++ b/Server.cs
@@ -1333,7 +1333,7 @@ namespace MCGalaxy
             }
             return Group.standard.color;
         }
-        public static void UpdateGlobalSettings()
+        /*public static void UpdateGlobalSettings()
         {
             try
             {
@@ -1358,7 +1358,7 @@ namespace MCGalaxy
                 gcnamebans.Clear();
                 gcipbans.Clear();
             }
-        }
+        }*/
         public void UpdateStaffList() {
             try {
                 devs.Clear();

--- a/Server.cs
+++ b/Server.cs
@@ -505,7 +505,7 @@ namespace MCGalaxy
                 	}
                 }
             }
-            UpdateGlobalSettings();
+            //UpdateGlobalSettings();
             if (!Directory.Exists("properties")) Directory.CreateDirectory("properties");
             if (!Directory.Exists("levels")) Directory.CreateDirectory("levels");
             if (!Directory.Exists("bots")) Directory.CreateDirectory("bots");


### PR DESCRIPTION
Reason for this commit is before if you were on Hetal728+2 and tried using /goto Hetal728+, it would state that the level is already loaded. This allows you to now go to level you have specified instead of returning that you are already on the level.
