### PR TITLE
Fix ExtInfo rarely arriving after ExtEntry.

### DIFF
--- a/Player/Player.cs
+++ b/Player/Player.cs
@@ -2623,7 +2623,7 @@ return;
             for ( int i = 0; i < send.Length; i++ ) {
                 buffer[i + 1] = send[i];
             }
-            if (id != 17)
+            if (!(id == 16 || id == 17)) // must send ExtEntry and ExtInfo packets synchronously.
             {
                 try
                 {


### PR DESCRIPTION
This means that CPE extensions will work again for classicube clients.

Note that this problem only seems to show up only on a few servers and some clients. Probably due to some clients being located far away from the server.
