### PR TITLE
Fix maxplayer overload

### DIFF
--- a/MCGalaxy/Network/ClassiCube.cs
+++ b/MCGalaxy/Network/ClassiCube.cs
@@ -86,6 +86,9 @@ namespace MCGalaxy {
             foreach (Player p in players) {
                 if (!p.hidden) count++;
             }
+            // This may happen if a VIP or a dev/mod joins an already full server.
+            if (count > Server.players)
+                count = Server.players;
             return count;
         }
         


### PR DESCRIPTION
This "overload" may happen if a VIP, Dev or Mod joins an already full server. Then when it'll heartbeat it'll give an error because the "users=" is higher than "max=" and eventually it'll disappear from the server list.