### PR TITLE
updating Minecraft skin database url

### DIFF
--- a/MCGalaxy/Commands/CPE/CmdSkin.cs
+++ b/MCGalaxy/Commands/CPE/CmdSkin.cs
@@ -68,7 +68,7 @@ namespace MCGalaxy.Commands.CPE {
         static string GetSkin(string skin, string defSkin) {
             if (skin.Length == 0) skin = defSkin;
             if (skin[0] == '+')
-                skin = "http://skins.minecraft.net/MinecraftSkins/" + skin.Substring(1) + ".png";
+                skin = "http://skins.mojang.com/" + skin.Substring(1) + ".png";
             
             CmdTexture.FilterURL(ref skin);
             return skin;


### PR DESCRIPTION
This updates the minecraft database url from skins.minecraft.net to the new address of skins.mojang.net