### PR TITLE
Fix the premium skin feature on /skin

### DIFF
--- a/MCGalaxy/Commands/CPE/CmdSkin.cs
+++ b/MCGalaxy/Commands/CPE/CmdSkin.cs
@@ -68,7 +68,7 @@ namespace MCGalaxy.Commands.CPE {
         static string GetSkin(string skin, string defSkin) {
             if (skin.Length == 0) skin = defSkin;
             if (skin[0] == '+')
-                skin = "http://skins.minecraft.net/MinecraftSkins/" + skin.Substring(1) + ".png";
+                skin = "https://minotar.net/skin/" + skin.Substring(1) + ".png";
             
             Utils.FilterURL(ref skin);
             return skin;


### PR DESCRIPTION
Since Mojang changed their link to get a premium Minecraft user's skin, it no longer works if you do /skin +[Premium username]

I replaced the link with minotar.net (another MC skin retriever). I have tested it and it does work, including the 2nd layer that some skins have.