### PR TITLE
Add /os map fixgrass

### DIFF
--- a/MCGalaxy/Commands/World/CmdOverseer.SubCommands.cs
+++ b/MCGalaxy/Commands/World/CmdOverseer.SubCommands.cs
@@ -124,7 +124,7 @@ namespace MCGalaxy.Commands.World {
                 if (value.Length == 0) value = "normal";
                 UseCommand(p, "Texture", "levelzip " + value);
             } else if (cmd == "FIXGRASS") {
-                UseCommand(p, "FixGrass", "");
+                UseCommand(p, "FixGrass " + value");
 	    } else {
                 LevelOption opt = LevelOptions.Find(cmd);
                 if (opt == null) {

--- a/MCGalaxy/Commands/World/CmdOverseer.SubCommands.cs
+++ b/MCGalaxy/Commands/World/CmdOverseer.SubCommands.cs
@@ -123,7 +123,9 @@ namespace MCGalaxy.Commands.World {
             } else if (cmd == "TEXTURE" || cmd == "TEXTUREZIP" || cmd == "TEXTUREPACK") {
                 if (value.Length == 0) value = "normal";
                 UseCommand(p, "Texture", "levelzip " + value);
-            } else {
+            } else if (cmd == "FIXGRASS") {
+                UseCommand(p, "FixGrass", "");
+	    } else {
                 LevelOption opt = LevelOptions.Find(cmd);
                 if (opt == null) {
                     p.MessageLines(mapHelp);


### PR DESCRIPTION
Prior to this commit, you had to use /fixgrass to fix grass. But on some servers /fixgrass is restricted to staff-only due to publicly buildable worlds such as freebuilds etc.