### PR TITLE
Line wrapper and colour simplification cleanup

### DIFF
--- a/MCGalaxy/Chat/Chat.cs
+++ b/MCGalaxy/Chat/Chat.cs
@@ -59,9 +59,7 @@ namespace MCGalaxy {
         
         public static string Format(string message, Player p, bool tokens = true, bool emotes = true) {
             message = Colors.Escape(message);
-            StringBuilder sb = new StringBuilder(message);
-            Colors.Cleanup(sb, p.hasTextColors);
-            
+            StringBuilder sb = new StringBuilder(message);      
             if (tokens) ChatTokens.Apply(sb, p);
             if (!emotes) return sb.ToString();
             

--- a/MCGalaxy/Chat/Colors.cs
+++ b/MCGalaxy/Chat/Colors.cs
@@ -283,8 +283,7 @@ namespace MCGalaxy {
             return new string(output, 0, usedChars);
         }
         
-        /// <summary> Removes all non-existent color codes, and converts
-        /// custom colors to their fallback standard color codes if required. </summary>
+        [Obsolete("LineWrapper.CleanupColors is a better alternative")]
         public static string Cleanup(string value, bool supportsCustomCols) {
             StringBuilder sb = new StringBuilder(value);
             Cleanup(sb, supportsCustomCols);

--- a/MCGalaxy/Chat/Colors.cs
+++ b/MCGalaxy/Chat/Colors.cs
@@ -169,9 +169,9 @@ namespace MCGalaxy {
         public static string ConvertMCToIRC(string input) {
             if (input == null) throw new ArgumentNullException("input");
             input = Escape(input);
-            StringBuilder sb = new StringBuilder(input);
-            Cleanup(sb, false);
+            input = LineWrapper.CleanupColors(input, true, false);
             
+            StringBuilder sb = new StringBuilder(input);
             for (int i = 0; i < ircColors.Length; i++) {
                 sb.Replace(ircReplacements[i], ircColors[i]);
             }
@@ -281,34 +281,6 @@ namespace MCGalaxy {
                 }
             }
             return new string(output, 0, usedChars);
-        }
-        
-        [Obsolete("LineWrapper.CleanupColors is a better alternative")]
-        public static string Cleanup(string value, bool supportsCustomCols) {
-            StringBuilder sb = new StringBuilder(value);
-            Cleanup(sb, supportsCustomCols);
-            return sb.ToString();
-        }
-        
-        /// <summary> Removes all non-existent color codes, and converts
-        /// custom colors to their fallback standard color codes if required. </summary>
-        public static void Cleanup(StringBuilder value, bool supportsCustomCols) {
-            for (int i = 0; i < value.Length; i++) {
-                char c = value[i];
-                if (c != '&' || i == value.Length - 1) continue;
-                // TODO: Not use for IRC
-                
-                char code = value[i + 1];
-                if (IsStandard(code)) {
-                    if (code >= 'A' && code <= 'F') {
-                        value[i + 1] += ' '; // WoM doesn't work with uppercase colors
-                    }
-                } else if (!IsDefined(code)) {
-                    value.Remove(i, 2); i--; // now need to check char at i again
-                } else if (!supportsCustomCols) {
-                    value[i + 1] = Get(code).Fallback;
-                }
-            }
         }
 
         

--- a/MCGalaxy/Chat/Colors.cs
+++ b/MCGalaxy/Chat/Colors.cs
@@ -296,6 +296,7 @@ namespace MCGalaxy {
             for (int i = 0; i < value.Length; i++) {
                 char c = value[i];
                 if (c != '&' || i == value.Length - 1) continue;
+                // TODO: Not use for IRC
                 
                 char code = value[i + 1];
                 if (IsStandard(code)) {

--- a/MCGalaxy/Chat/EmotesHandler.cs
+++ b/MCGalaxy/Chat/EmotesHandler.cs
@@ -50,47 +50,39 @@ namespace MCGalaxy {
             "█▄▌▐▀αßΓπΣσµτΦΘΩδ∞φε∩≡±≥≤⌠⌡÷≈°∙·√ⁿ²■\u00a0";
         
         public static string Replace(string message) {
-            return Unescape(message, '(', ')', Keywords);
-        }
-        
-        public static string Unescape(string message, char start, char end, 
-                                      Dictionary<string, char> tokens)
-        {
-            if (message == null)
-                throw new ArgumentNullException("message");
-            int startIndex = message.IndexOf(start);
-            if (startIndex == -1) return message;
+            Dictionary<string, char> tokens = Keywords;
+            int begIndex = message.IndexOf('(');
+            if (begIndex == -1) return message;
 
-            StringBuilder output = new StringBuilder(message.Length);
+            StringBuilder output  = new StringBuilder(message.Length);
             int lastAppendedIndex = 0;
-            while (startIndex != -1) {
-                int endIndex = message.IndexOf(end, startIndex + 1);
-                if (endIndex == -1)
-                    break;
+            while (begIndex != -1) {
+                int endIndex = message.IndexOf(')', begIndex + 1);
+                if (endIndex == -1) break;
 
                 bool escaped = false;
-                for (int i = startIndex - 1; i >= 0 && message[i] == '\\'; i--) {
+                for (int i = begIndex - 1; i >= 0 && message[i] == '\\'; i--) {
                     escaped = !escaped;
                 }
 
-                string keyword = message.Substring(startIndex + 1, endIndex - startIndex - 1);
+                string keyword = message.Substring(begIndex + 1, endIndex - begIndex - 1);
                 char substitute;
                 if (tokens.TryGetValue(keyword.ToLowerInvariant(), out substitute))
                 {
                     if (escaped) {
-                        startIndex++;
-                        output.Append(message, lastAppendedIndex, startIndex - lastAppendedIndex - 2);
-                        lastAppendedIndex = startIndex - 1;
+                        begIndex++;
+                        output.Append(message, lastAppendedIndex, begIndex - lastAppendedIndex - 2);
+                        lastAppendedIndex = begIndex - 1;
                     } else {
-                        output.Append(message, lastAppendedIndex, startIndex - lastAppendedIndex);
+                        output.Append(message, lastAppendedIndex, begIndex - lastAppendedIndex);
                         output.Append(substitute);
-                        startIndex = endIndex + 1;
-                        lastAppendedIndex = startIndex;
+                        begIndex = endIndex + 1;
+                        lastAppendedIndex = begIndex;
                     }
                 } else {
-                    startIndex++;
+                    begIndex++;
                 }
-                startIndex = message.IndexOf(start, startIndex);
+                begIndex = message.IndexOf('(', begIndex);
             }
             output.Append(message, lastAppendedIndex, message.Length - lastAppendedIndex);
             return output.ToString();

--- a/MCGalaxy/Chat/LineWrapper.cs
+++ b/MCGalaxy/Chat/LineWrapper.cs
@@ -30,8 +30,8 @@ namespace MCGalaxy {
             return '\0';
         }
         
-		// try to wrap on cut off words
-		// TODO: fix this to do AFTER wrapper char
+        // try to wrap on cut off words
+        // TODO: fix this to do AFTER wrapper char
         static bool IsWrapper(char c) {
             return c == ' ' || c == '-' || c == '/' || c == '\\';
         }
@@ -40,7 +40,7 @@ namespace MCGalaxy {
         public static List<string> Wordwrap(string message, bool supportsEmotes) {
             List<string> lines   = new List<string>();
             const int limit      = NetUtils.StringSize; // max characters on one line
-            const int maxLineLen = limit + 2; // +2 in case text is longer than one line
+            const int maxLineLen = limit + 1; // +1 because need to know if length of line overshot limit
             char[] line = new char[maxLineLen];
             
             bool firstLine   = true;
@@ -58,6 +58,13 @@ namespace MCGalaxy {
                     // Make sure split up lines have the right colour
                     if (prevColCode != '\0') {
                         line[2] = '&'; line[3] = prevColCode;
+                        length += 2;
+                    }
+                } else if (!supportsEmotes) {
+                    // If message starts with emote then prepend &f
+                    // (otherwise original minecraft classic trims it)
+                    if (message[0] < ' ' || message[0] > '~') {
+                        line[0] = '&'; line[1] = 'f';
                         length += 2;
                     }
                 }

--- a/MCGalaxy/Chat/LineWrapper.cs
+++ b/MCGalaxy/Chat/LineWrapper.cs
@@ -40,7 +40,7 @@ namespace MCGalaxy {
             const int maxLineLen = limit + 2;      // +2 in case text is longer than one line
             char[] line = new char[maxLineLen];
             
-            bool multilined  = false;
+            bool firstLine   = true;
             char prevColCode = '\0';
             int trim;
             // TODO: How does < 32 or > 127 behave with original java client
@@ -48,7 +48,7 @@ namespace MCGalaxy {
             for (int offset = 0; offset < message.Length; ) {
                 int length = 0;
                 // "Line1", "> Line2", "> Line3"
-                if (multilined) {
+                if (!firstLine) {
                     line[0] = '>'; line[1] = ' ';
                     length += 2;
                     
@@ -60,8 +60,9 @@ namespace MCGalaxy {
                 }
                 
                 // Copy across text up to current line length
-                // Also trim the line of starting spaces
-                bool foundStart = false;
+                // Also trim the line of starting spaces on subsequent lines
+                // (note first line is NOT trimmed for spaces)
+                bool foundStart = firstLine;
                 for (; length < maxLineLen && offset < message.Length;) {
                     char c = message[offset++];
                     
@@ -76,7 +77,7 @@ namespace MCGalaxy {
                     lines.Add(new string(line, 0, length));
                     break;
                 }
-                multilined = true;
+                firstLine = false;
                 
                 // Try to split up this line nicely
                 for (int i = limit - 1; i > limit - 20; i--) {

--- a/MCGalaxy/Chat/LineWrapper.cs
+++ b/MCGalaxy/Chat/LineWrapper.cs
@@ -45,9 +45,7 @@ namespace MCGalaxy {
 			if (emoteFix) line[length++] = '\'';
 			return new string(line, 0, length);
 		}
-        
-        // try to wrap on cut off words
-        // TODO: fix this to do AFTER wrapper char
+
         static bool IsWrapper(char c) {
             return c == ' ' || c == '-' || c == '/' || c == '\\';
         }
@@ -57,11 +55,10 @@ namespace MCGalaxy {
             List<string> lines   = new List<string>();
             const int limit      = NetUtils.StringSize; // max characters on one line
             const int maxLineLen = limit + 1; // +1 because need to know if length of line overshot limit
-            char[] line = new char[maxLineLen];
             
+            char[] line    = new char[maxLineLen];
             bool firstLine = true;
             char lastColor = 'f';
-            int trim;
             
             for (int offset = 0; offset < message.Length; ) {
                 int length = 0;
@@ -86,7 +83,7 @@ namespace MCGalaxy {
                 }
                 
                 // Copy across text up to current line length
-                // Also trim the line of starting spaces on subsequent lines
+                // Also trim leading spaces on subsequent lines
                 // (note that first line is NOT trimmed for spaces)
                 bool foundStart = firstLine;
                 for (; length < maxLineLen && offset < message.Length;) {
@@ -101,6 +98,7 @@ namespace MCGalaxy {
                 int lineLength = limit;
                 bool emoteFix  = false;
                 // Check if need to add padding ' to line end
+                // (Lines ended in emote are trimmed by minecraft classic client)
                 if (!supportsEmotes && EndsInEmote(line, length, lineLength)) {
                     lineLength--;
                     // If last character on line was an emote, but second last
@@ -120,15 +118,16 @@ namespace MCGalaxy {
                 for (int i = lineLength - 1; i > limit - 20; i--) {
                     if (!IsWrapper(line[i])) continue;
                     
-                    trim = length - i;
-                    length -= trim; offset -= trim;
+                    i++; // include line wrapper character on this line
+                    offset -= length - i;
+                    length  = i;
                     break;
                 }
                 
                 // Couldn't split line up? Deal with leftover characters next line
                 if (length > lineLength) {
-                    trim = length - lineLength;
-                    length -= trim; offset -= trim;
+                    offset -= length - lineLength;
+                    length  = lineLength;
                 }
                 
                 // Don't split up line in middle of colour code

--- a/MCGalaxy/Chat/LineWrapper.cs
+++ b/MCGalaxy/Chat/LineWrapper.cs
@@ -21,8 +21,8 @@ namespace MCGalaxy {
     public static class LineWrapper {
         
         static bool EndsInEmote(char[] line, int length, int lineLength) {
-			length = Math.Min(length, lineLength);
-			
+            length = Math.Min(length, lineLength);
+            
             // skip trailing spaces
             for (; length > 0 & line[length - 1] == ' '; length--) { }
             if (length == 0) return false;
@@ -40,11 +40,11 @@ namespace MCGalaxy {
             }
             return 'f';
         }
-		
-		static string MakeLine(char[] line, int length, bool emoteFix) {
-			if (emoteFix) line[length++] = '\'';
-			return new string(line, 0, length);
-		}
+        
+        static string MakeLine(char[] line, int length, bool emoteFix) {
+            if (emoteFix) line[length++] = '\'';
+            return new string(line, 0, length);
+        }
 
         static bool IsWrapper(char c) {
             return c == ' ' || c == '-' || c == '/' || c == '\\';
@@ -109,7 +109,7 @@ namespace MCGalaxy {
                 
                 // No need for any more linewrapping?
                 if (length < lineLength) {
-                	lines.Add(MakeLine(line, length, emoteFix));
+                    lines.Add(MakeLine(line, length, emoteFix));
                     break;
                 }
                 firstLine = false;
@@ -140,11 +140,20 @@ namespace MCGalaxy {
         }
         
         static bool ValidColor(char c) { return Colors.IsStandard(c) || Colors.IsDefined(c); }
+
+        public static string CleanupColors(string value, Player p) {
+            // Although ClassiCube in classic mode supports invalid colours,
+            //  the original vanilla client crashes with invalid colour codes
+            // Since it's impossible to identify which client is being used,
+            //  just remove the ampersands to be on the safe side
+            //  when text colours extension is not supported
+            return CleanupColors(value, p.hasTextColors, p.hasTextColors);
+        }
         
         /// <summary> Removes redundant colour codes and fixes some colour codes to behave correctly for older clients </summary>
-        /// <param name="supportsCustomCols">if false, fixes colour codes for compatibility 
-        /// (e.g. converts custom colour codes into fallback colour code) </param>
-        public static string CleanupColors(string value, bool supportsCustomCols) {
+        /// <param name="fullAmpersands"> if false, ampersands not followed by valid colour code are removed </param>
+        /// <param name="customCols"> if false, converts custom colour codes into fallback colour code </param>
+        public static string CleanupColors(string value, bool fullAmpersands, bool customCols) {
             if (value.IndexOf('&') == -1) return value;
             StringBuilder sb = new StringBuilder(value.Length);
             int lastIdx  = -1;
@@ -161,11 +170,8 @@ namespace MCGalaxy {
                 
                 // Maybe still not a colour code
                 if (i == value.Length - 1 || !ValidColor(value[i + 1])) {
-                    if (!supportsCustomCols) {
-                        // Although ClassiCube in classic mode supports invalid colours,
-                        //  the original vanilla client crashes with invalid colour codes
-                        // Since it's impossible to identify which client is being used,
-                        //  just remove the ampersands to be on the safe side
+                    if (!fullAmpersands) {
+                        // Client doesn't support standalone & 
                         i++;
                     } else {
                         // Treat the & like a normal character
@@ -178,7 +184,7 @@ namespace MCGalaxy {
                 char col = value[i + 1];
                 // A-F --> a-f
                 if (col >= 'A' && col <= 'F') col += ' ';
-                if (!supportsCustomCols) col = Colors.Get(col).Fallback;
+                if (!customCols) col = Colors.Get(col).Fallback;
                 
                 // Don't append duplicate colour codes
                 if (lastCol != col) {

--- a/MCGalaxy/Chat/LineWrapper.cs
+++ b/MCGalaxy/Chat/LineWrapper.cs
@@ -103,7 +103,10 @@ namespace MCGalaxy {
                 // Check if need to add padding ' to line end
                 if (!supportsEmotes && EndsInEmote(line, length, lineLength)) {
                     lineLength--;
-                    emoteFix = true;
+                    // If last character on line was an emote, but second last
+                    // is NOT an emote, then don't add the trailing ' to line
+                    // TODO: avoid calling twice? probably doesn't even matter
+                    emoteFix = EndsInEmote(line, length, lineLength);
                 }
                 
                 // No need for any more linewrapping?
@@ -114,7 +117,7 @@ namespace MCGalaxy {
                 firstLine = false;
                 
                 // Try to split up this line nicely
-                for (int i = limit - 1; i > limit - 20; i--) {
+                for (int i = lineLength - 1; i > limit - 20; i--) {
                     if (!IsWrapper(line[i])) continue;
                     
                     trim = length - i;

--- a/MCGalaxy/Chat/LineWrapper.cs
+++ b/MCGalaxy/Chat/LineWrapper.cs
@@ -30,17 +30,17 @@ namespace MCGalaxy {
             return '\0';
         }
         
+		// try to wrap on cut off words
+		// TODO: fix this to do AFTER wrapper char
         static bool IsWrapper(char c) {
             return c == ' ' || c == '-' || c == '/' || c == '\\';
         }
         
         // TODO: Add outputLine argument, instead of returning string list
-        public static List<string> Wordwrap(string message, bool supportsCustomCols) {
-            List<string> lines = new List<string>();
-            message = CleanupColors(message, supportsCustomCols);
-
-            const int limit = NetUtils.StringSize; // max characters on one line
-            const int maxLineLen = limit + 2;      // +2 in case text is longer than one line
+        public static List<string> Wordwrap(string message, bool supportsEmotes) {
+            List<string> lines   = new List<string>();
+            const int limit      = NetUtils.StringSize; // max characters on one line
+            const int maxLineLen = limit + 2; // +2 in case text is longer than one line
             char[] line = new char[maxLineLen];
             
             bool firstLine   = true;
@@ -64,7 +64,7 @@ namespace MCGalaxy {
                 
                 // Copy across text up to current line length
                 // Also trim the line of starting spaces on subsequent lines
-                // (note first line is NOT trimmed for spaces)
+                // (note that first line is NOT trimmed for spaces)
                 bool foundStart = firstLine;
                 for (; length < maxLineLen && offset < message.Length;) {
                     char c = message[offset++];

--- a/MCGalaxy/Entity/Entities.cs
+++ b/MCGalaxy/Entity/Entities.cs
@@ -135,7 +135,7 @@ namespace MCGalaxy {
                              string skin, string name, string model) {
             // NOTE: Fix for standard clients
             if (id == Entities.SelfID) pos.Y -= 22;
-            name = Colors.Cleanup(name, dst.hasTextColors);           
+            name = LineWrapper.CleanupColors(name, dst.hasTextColors);
             
             if (dst.Supports(CpeExt.ExtPlayerList, 2)) {
                 dst.Send(Packet.ExtAddEntity2(id, skin, name, pos, rot, dst.hasCP437, dst.hasExtPositions));

--- a/MCGalaxy/Entity/Entities.cs
+++ b/MCGalaxy/Entity/Entities.cs
@@ -135,7 +135,7 @@ namespace MCGalaxy {
                              string skin, string name, string model) {
             // NOTE: Fix for standard clients
             if (id == Entities.SelfID) pos.Y -= 22;
-            name = LineWrapper.CleanupColors(name, dst.hasTextColors);
+            name = LineWrapper.CleanupColors(name, dst);
             
             if (dst.Supports(CpeExt.ExtPlayerList, 2)) {
                 dst.Send(Packet.ExtAddEntity2(id, skin, name, pos, rot, dst.hasCP437, dst.hasExtPositions));

--- a/MCGalaxy/Entity/TabList.cs
+++ b/MCGalaxy/Entity/TabList.cs
@@ -37,8 +37,8 @@ namespace MCGalaxy {
             GetEntry(p, dst, out name, out group);
             
             name  = Colors.Escape(name); // for nicks
-            name  = Colors.Cleanup(name, dst.hasTextColors);
-            group = Colors.Cleanup(group, dst.hasTextColors);
+            name  = LineWrapper.CleanupColors(name,  dst.hasTextColors);
+            group = LineWrapper.CleanupColors(group, dst.hasTextColors);
             dst.Send(Packet.ExtAddPlayerName(id, p.truename, name, group, grpPerm, dst.hasCP437));
         }
         

--- a/MCGalaxy/Entity/TabList.cs
+++ b/MCGalaxy/Entity/TabList.cs
@@ -37,8 +37,8 @@ namespace MCGalaxy {
             GetEntry(p, dst, out name, out group);
             
             name  = Colors.Escape(name); // for nicks
-            name  = LineWrapper.CleanupColors(name,  dst.hasTextColors);
-            group = LineWrapper.CleanupColors(group, dst.hasTextColors);
+            name  = LineWrapper.CleanupColors(name,  dst);
+            group = LineWrapper.CleanupColors(group, dst);
             dst.Send(Packet.ExtAddPlayerName(id, p.truename, name, group, grpPerm, dst.hasCP437));
         }
         

--- a/MCGalaxy/Network/Player.Networking.cs
+++ b/MCGalaxy/Network/Player.Networking.cs
@@ -176,7 +176,7 @@ namespace MCGalaxy {
             if (cancelmessage) { cancelmessage = false; return; }
             
             try {
-                message = LineWrapper.CleanupColors(message, hasTextColors);
+                message = LineWrapper.CleanupColors(message, this);
                 SendLines(LineWrapper.Wordwrap(message, hasEmoteFix), type);
             } catch (Exception e) {
                 Logger.LogError(e);
@@ -198,7 +198,7 @@ namespace MCGalaxy {
             }
             
             message = Chat.Format(message, this);
-            message = LineWrapper.CleanupColors(message, hasTextColors);
+            message = LineWrapper.CleanupColors(message, this);
             Send(Packet.Message(message, type, hasCP437));
         }
 

--- a/MCGalaxy/Network/Player.Networking.cs
+++ b/MCGalaxy/Network/Player.Networking.cs
@@ -178,7 +178,7 @@ namespace MCGalaxy {
             if (cancelmessage) { cancelmessage = false; return; }
             
             try {
-                SendLines(LineWrapper.Wordwrap(message), type);
+                SendLines(LineWrapper.Wordwrap(message, hasTextColors), type);
             } catch (Exception e) {
                 Logger.LogError(e);
             }

--- a/MCGalaxy/Network/Player.Networking.cs
+++ b/MCGalaxy/Network/Player.Networking.cs
@@ -160,9 +160,7 @@ namespace MCGalaxy {
                 byte[] data = new byte[count * 66];
                 
                 for (int j = 0; j < count; i++, j++) {
-                    string line = lines[i];
-                    if (!Supports(CpeExt.EmoteFix) && LineEndsInEmote(line)) line += '\'';
-                    Packet.WriteMessage(line, type, hasCP437, data, j * 66);
+                    Packet.WriteMessage(lines[i], type, hasCP437, data, j * 66);
                 }
                 Send(data);
             }
@@ -178,7 +176,8 @@ namespace MCGalaxy {
             if (cancelmessage) { cancelmessage = false; return; }
             
             try {
-                SendLines(LineWrapper.Wordwrap(message, hasTextColors), type);
+                message = LineWrapper.CleanupColors(message, hasTextColors);
+                SendLines(LineWrapper.Wordwrap(message, hasEmoteFix), type);
             } catch (Exception e) {
                 Logger.LogError(e);
             }
@@ -199,6 +198,7 @@ namespace MCGalaxy {
             }
             
             message = Chat.Format(message, this);
+            message = LineWrapper.CleanupColors(message, hasTextColors);
             Send(Packet.Message(message, type, hasCP437));
         }
 

--- a/MCGalaxy/Player/Player.CPE.cs
+++ b/MCGalaxy/Player/Player.CPE.cs
@@ -63,7 +63,7 @@ namespace MCGalaxy {
         }
         
         // these are checked very frequently, so avoid overhead of .Supports(
-        public bool hasCustomBlocks, hasBlockDefs, hasTextColors, hasExtBlocks,
+        public bool hasCustomBlocks, hasBlockDefs, hasTextColors, hasExtBlocks, hasEmoteFix,
         hasChangeModel, hasExtList, hasCP437, hasTwoWayPing, hasBulkBlockUpdate, hasExtTexs;
 
         void AddExtension(string extName, int version) {
@@ -77,6 +77,8 @@ namespace MCGalaxy {
                 if (MaxRawBlock < Block.CpeMaxBlock) MaxRawBlock = Block.CpeMaxBlock;
             } else if (ext.Name == CpeExt.ChangeModel) {
                 hasChangeModel = true;
+            } else if (ext.Name == CpeExt.EmoteFix) {
+                hasEmoteFix = true;
             } else if (ext.Name == CpeExt.FullCP437) {
                 hasCP437 = true;
             } else if (ext.Name == CpeExt.ExtPlayerList) {


### PR DESCRIPTION
This pull request majorly improves line wrapping and colour code simplification:
* Fixes cases where non-classic colour codes could get sent and crash vanilla
* Fixes if line ends with emote, that emote would always be trimmed
* Supports more cases for removing redundant colour codes
* Supports removing redundant custom colour codes
* Fixes some messages causing excessive memory use
* Lines rarely chopped in middle of a colour code
* Additionally attempts to nicely word wrap on -,/,\ too
* Code style is improved to not use goto and try/catch


Closes #494 and #163