### PR TITLE
Fix /pass bypass security issue.

### DIFF
--- a/MCGalaxy/Commands/Moderation/CmdPass.cs
+++ b/MCGalaxy/Commands/Moderation/CmdPass.cs
@@ -143,10 +143,6 @@ namespace MCGalaxy.Commands.Moderation {
 #endif
 
         static byte[] ComputeHash(string name, string pass) {
-            // Pointless, but kept for backwards compatibility
-            pass = pass.Replace("<", "(");
-            pass = pass.Replace(">", ")");
-
             // The constant string added to the username salt is to mitigate
             // rainbox tables. We should really have a unique salt for each
             // user, but this is close enough.

--- a/MCGalaxy/Commands/Moderation/CmdPass.cs
+++ b/MCGalaxy/Commands/Moderation/CmdPass.cs
@@ -146,7 +146,7 @@ namespace MCGalaxy.Commands.Moderation {
             // The constant string added to the username salt is to mitigate
             // rainbox tables. We should really have a unique salt for each
             // user, but this is close enough.
-            return SHA256.Create().ComputeHash(Encoding.UTF8.GetBytes("MCGalaxy:" + name.ToLower() + " " + pass));
+            return SHA256.Create().ComputeHash(Encoding.UTF8.GetBytes("0bec662b-416f-450c-8f50-664fd4a41d49" + name.ToLower() + " " + pass));
         }
 
         static bool CheckHash(string name, string pass) {

--- a/MCGalaxy/Commands/Moderation/CmdPass.cs
+++ b/MCGalaxy/Commands/Moderation/CmdPass.cs
@@ -202,6 +202,9 @@ namespace MCGalaxy.Commands.Moderation {
                 return PassName;
 
             string OldName = "extra/passwords/" + name + ".dat";
+            if (File.Exists(PassName))
+                return PassName;
+
             string directory = Path.GetDirectoryName(OldName);
             IEnumerable<string> foundFiles = EnumerateFilesCI(directory, OldName);
 

--- a/MCGalaxy/Player/Player.cs
+++ b/MCGalaxy/Player/Player.cs
@@ -357,7 +357,7 @@ namespace MCGalaxy {
             Unverified = Server.Config.verifyadmins && Rank >= Server.Config.VerifyAdminsRank;
             if (!Unverified) return;
             
-            if (!File.Exists("extra/passwords/" + name + ".dat")) {
+            if (!Commands.Moderation.CmdPass.HasPassword(name)) {
                 Message("%WPlease set your admin verification password with %T/SetPass [password]!");
             } else {
                 Message("%WPlease complete admin verification with %T/Pass [password]!");


### PR DESCRIPTION


Mitigation:
    If verify-names is enabled the authentication is handled by the TPP
    that server overrides the username processing.  The default server,
    classicube.net, uses case sensitive names with the initial logon
    mapping the entered userid to the correct case. It is expected that
    alternate servers will also not allow user names that collide under
    case conversion.

Issue:
    The username is usually treated as case insensitive, however,
    the password is stored in a file with the user name in it's name.
    For filesystems that ignore case this will only occasionally an issue
    if unicode case conversion is inconsistent. But linux filesystems
    do not ignore case so all letters (and letter like characters)
    in the username have two representations.

Contributory factor:
    If the password file for a particular userid is not found the user
    is prompted to enter a new password without any authenticatin.


Other notes:
It may also be a good idea to use a conversion to lowercase when creating the salt for the password file from the username. As it currently stands if a user enters the wrong case for their username they will get a wrong password prompt rather than the previous issue of having to use /setpass without authentication.

