### PR TITLE
Use Colors.Strip when unloading plugins

### DIFF
--- a/MCGalaxy/Commands/Scripting/CmdPlugin.cs
+++ b/MCGalaxy/Commands/Scripting/CmdPlugin.cs
@@ -83,7 +83,7 @@ namespace MCGalaxy.Commands.Scripting {
         
         static void UnloadPlugin(Player p, string name) {
             int matches;
-            Plugin plugin = Matcher.Find(p, name, out matches, Plugin.all, 
+            Plugin plugin = Matcher.Find(p, Colors.Strip(name), out matches, Plugin.all,
                                          null, pln => pln.name, "plugins");
             if (plugin == null) return;
             


### PR DESCRIPTION
Some plugins use colour codes to make them stand out in the /plugins list. Prior to this, you could not unload plugins due to the colour code but using Colors.Strip() before finding will fix this.

Fixes ClassiCube/MCGalaxy-Plugins#5 and derekdinan/ClassiCube-Stuff#2