### PR TITLE
/color without the color specified should remove the color completely

### DIFF
--- a/MCGalaxy/Commands/Chat/CmdColor.cs
+++ b/MCGalaxy/Commands/Chat/CmdColor.cs
@@ -54,14 +54,15 @@ namespace MCGalaxy.Commands.Chatting {
             if (colName.Length == 0) {
                 col = Group.GroupIn(target).Color;
                 MessageFrom(target, who, "had their color removed");
+                PlayerDB.Update(target, PlayerData.ColumnColor, "");
             } else {
                 col = Matcher.FindColor(p, colName);
                 if (col == null) return;
                 MessageFrom(target, who, "had their color changed to " + col + Colors.Name(col));
+                PlayerDB.Update(target, PlayerData.ColumnColor, col);
             }
             
             if (who != null) who.UpdateColor(col);
-            PlayerDB.Update(target, PlayerData.ColumnColor, col);
         }
         
         public override void Help(Player p) {


### PR DESCRIPTION
\>Player resets their color
\>Color gets set to their rank's color
\>Their rank/rank's color changes
\>Color doesn't match rank color anymore

This commit fixes that