### PR TITLE
Changes to ignoring messages.

### DIFF
--- a/MCGalaxy/Blocks/BlockOptions.cs
+++ b/MCGalaxy/Blocks/BlockOptions.cs
@@ -114,8 +114,10 @@ namespace MCGalaxy.Blocks {
         
         static void Toggle(Player p, BlockProps[] scope, BlockID block, string type, ref bool on) {
             on = !on;
-            string name = BlockProps.ScopedName(scope, p, block);
-            p.Message("Block {0} is {1}: {2}", name, type, on ? "&aYes" : "&cNo");
+            if (!p.Ignores.DrawOutput) {
+                string name = BlockProps.ScopedName(scope, p, block);
+                p.Message("Block {0} is {1}: {2}", name, type, on ? "&aYes" : "&cNo");
+            }
         }
         
         static void SetAI(Player p, BlockProps[] scope, BlockID block, string msg) {
@@ -150,7 +152,7 @@ namespace MCGalaxy.Blocks {
             string name = BlockProps.ScopedName(scope, p, block);
             if (stackBlock == Block.Air) {
                 p.Message("Removed stack block for {0}", name);
-            } else {
+            } else if (!p.Ignores.DrawOutput) {
                 p.Message("Stack block for {0} set to: {1}",
                           name, BlockProps.ScopedName(scope, p, stackBlock));
             }
@@ -168,8 +170,9 @@ namespace MCGalaxy.Blocks {
                 if (other == block) { p.Message("ID of {0} must be different.", type); return; }
                 
                 target = other;
-                p.Message("{2} for {0} set to: {1}",
-                          name, BlockProps.ScopedName(scope, p, other), type);
+                if (!p.Ignores.DrawOutput && p.Supports(CpeExt.MessageTypes))
+                    p.Message("{2} for {0} set to: {1}",
+                              name, BlockProps.ScopedName(scope, p, other), type);
             }
         }
     }

--- a/MCGalaxy/Blocks/BlockOptions.cs
+++ b/MCGalaxy/Blocks/BlockOptions.cs
@@ -114,7 +114,7 @@ namespace MCGalaxy.Blocks {
         
         static void Toggle(Player p, BlockProps[] scope, BlockID block, string type, ref bool on) {
             on = !on;
-            if (!p.Ignores.DrawOutput) {
+            if (!p.Ignores.BlockdefChanges) {
                 string name = BlockProps.ScopedName(scope, p, block);
                 p.Message("Block {0} is {1}: {2}", name, type, on ? "&aYes" : "&cNo");
             }
@@ -152,7 +152,7 @@ namespace MCGalaxy.Blocks {
             string name = BlockProps.ScopedName(scope, p, block);
             if (stackBlock == Block.Air) {
                 p.Message("Removed stack block for {0}", name);
-            } else if (!p.Ignores.DrawOutput) {
+            } else if (!p.Ignores.BlockdefChanges) {
                 p.Message("Stack block for {0} set to: {1}",
                           name, BlockProps.ScopedName(scope, p, stackBlock));
             }
@@ -170,7 +170,7 @@ namespace MCGalaxy.Blocks {
                 if (other == block) { p.Message("ID of {0} must be different.", type); return; }
                 
                 target = other;
-                if (!p.Ignores.DrawOutput && p.Supports(CpeExt.MessageTypes))
+                if (!p.Ignores.BlockdefChanges)
                     p.Message("{2} for {0} set to: {1}",
                               name, BlockProps.ScopedName(scope, p, other), type);
             }

--- a/MCGalaxy/Commands/CPE/CustomBlockCommand.cs
+++ b/MCGalaxy/Commands/CPE/CustomBlockCommand.cs
@@ -161,7 +161,7 @@ namespace MCGalaxy.Commands.CPE {
                 copied++;
                 
                 string scope = global ? "global" : "level";
-                if (!p.Ignores.DrawOutput)
+                if (!p.Ignores.BlockdefChanges)
                     p.Message("Copied the {0} custom block with id \"{1}\".", scope, Block.ToRaw(b));
             }
             
@@ -197,7 +197,7 @@ namespace MCGalaxy.Commands.CPE {
                 if (!DoCopy(p, lvl, global, cmd, false, defs[src], src, dst)) continue;
                 string scope = global ? "global" : "level";
                 
-                if (!p.Ignores.DrawOutput)
+                if (!p.Ignores.BlockdefChanges)
                     p.Message("Duplicated the {0} custom block with id \"{1}\" to \"{2}\".", 
                           scope, i, Block.ToRaw(dst));
                 changed = true;
@@ -286,7 +286,7 @@ namespace MCGalaxy.Commands.CPE {
             BlockDefinition[] defs = global ? BlockDefinition.GlobalDefs : lvl.CustomBlockDefs;
             BlockDefinition def = defs[block];
             if (!ExistsInScope(def, block, global)) {
-                if (!p.Ignores.DrawOutput)
+                if (!p.Ignores.BlockdefChanges)
                     MessageNoBlock(p, block, global, cmd);
                 return false;
             }
@@ -295,7 +295,7 @@ namespace MCGalaxy.Commands.CPE {
             ResetProps(global, lvl, block, p);          
             
             string scope = global ? "global" : "level";
-            if (!p.Ignores.DrawOutput)
+            if (!p.Ignores.BlockdefChanges)
                 p.Message("Removed " + scope + " custom block " + def.Name + "(" + def.RawID + ")");
             
             BlockDefinition globalDef = BlockDefinition.GlobalDefs[block];
@@ -532,7 +532,7 @@ namespace MCGalaxy.Commands.CPE {
                     
                     def.InventoryOrder = order == def.RawID ? -1 : order;
                     BlockDefinition.UpdateOrder(def, global, lvl);
-                    if (!p.Ignores.DrawOutput)
+                    if (!p.Ignores.BlockdefChanges)
                         p.Message("Set inventory order for {0} to {1}", blockName,
                                    order == def.RawID ? "default" : order.ToString());
                     return true;
@@ -540,7 +540,7 @@ namespace MCGalaxy.Commands.CPE {
                     p.Message("Unrecognised property: " + arg); return false;
             }
             
-            if (!p.Ignores.DrawOutput)
+            if (!p.Ignores.BlockdefChanges)
                 p.Message("Set {0} for {1} to {2}", arg, blockName, value);
             BlockDefinition.Add(def, defs, lvl);
             if (changedFallback) {
@@ -578,7 +578,7 @@ namespace MCGalaxy.Commands.CPE {
             BlockID block = def.GetBlock();
 
             string scope  = global ? "global" : "level";
-            if (!p.Ignores.DrawOutput)
+            if (!p.Ignores.BlockdefChanges)
                 p.Message("Created a new " + scope + " custom block " + def.Name + "(" + def.RawID + ")");
             
             block = def.GetBlock();

--- a/MCGalaxy/Commands/CPE/CustomBlockCommand.cs
+++ b/MCGalaxy/Commands/CPE/CustomBlockCommand.cs
@@ -161,7 +161,8 @@ namespace MCGalaxy.Commands.CPE {
                 copied++;
                 
                 string scope = global ? "global" : "level";
-                p.Message("Copied the {0} custom block with id \"{1}\".", scope, Block.ToRaw(b));
+                if (!p.Ignores.DrawOutput)
+                    p.Message("Copied the {0} custom block with id \"{1}\".", scope, Block.ToRaw(b));
             }
             
             p.Message("{0} custom blocks were copied from level {1}", 
@@ -196,7 +197,8 @@ namespace MCGalaxy.Commands.CPE {
                 if (!DoCopy(p, lvl, global, cmd, false, defs[src], src, dst)) continue;
                 string scope = global ? "global" : "level";
                 
-                p.Message("Duplicated the {0} custom block with id \"{1}\" to \"{2}\".", 
+                if (!p.Ignores.DrawOutput)
+                    p.Message("Duplicated the {0} custom block with id \"{1}\" to \"{2}\".", 
                           scope, i, Block.ToRaw(dst));
                 changed = true;
             }
@@ -283,13 +285,18 @@ namespace MCGalaxy.Commands.CPE {
                              bool global, string cmd) {
             BlockDefinition[] defs = global ? BlockDefinition.GlobalDefs : lvl.CustomBlockDefs;
             BlockDefinition def = defs[block];
-            if (!ExistsInScope(def, block, global)) { MessageNoBlock(p, block, global, cmd); return false; }
+            if (!ExistsInScope(def, block, global)) {
+                if (!p.Ignores.DrawOutput)
+                    MessageNoBlock(p, block, global, cmd);
+                return false;
+            }
             
             BlockDefinition.Remove(def, defs, lvl);
             ResetProps(global, lvl, block, p);          
             
             string scope = global ? "global" : "level";
-            p.Message("Removed " + scope + " custom block " + def.Name + "(" + def.RawID + ")");
+            if (!p.Ignores.DrawOutput)
+                p.Message("Removed " + scope + " custom block " + def.Name + "(" + def.RawID + ")");
             
             BlockDefinition globalDef = BlockDefinition.GlobalDefs[block];
             if (!global && globalDef != null)
@@ -525,14 +532,16 @@ namespace MCGalaxy.Commands.CPE {
                     
                     def.InventoryOrder = order == def.RawID ? -1 : order;
                     BlockDefinition.UpdateOrder(def, global, lvl);
-                    p.Message("Set inventory order for {0} to {1}", blockName,
+                    if (!p.Ignores.DrawOutput)
+                        p.Message("Set inventory order for {0} to {1}", blockName,
                                    order == def.RawID ? "default" : order.ToString());
                     return true;
                 default:
                     p.Message("Unrecognised property: " + arg); return false;
             }
             
-            p.Message("Set {0} for {1} to {2}", arg, blockName, value);
+            if (!p.Ignores.DrawOutput)
+                p.Message("Set {0} for {1} to {2}", arg, blockName, value);
             BlockDefinition.Add(def, defs, lvl);
             if (changedFallback) {
                 BlockDefinition.UpdateFallback(global, def.GetBlock(), lvl);
@@ -569,7 +578,8 @@ namespace MCGalaxy.Commands.CPE {
             BlockID block = def.GetBlock();
 
             string scope  = global ? "global" : "level";
-            p.Message("Created a new " + scope + " custom block " + def.Name + "(" + def.RawID + ")");
+            if (!p.Ignores.DrawOutput)
+                p.Message("Created a new " + scope + " custom block " + def.Name + "(" + def.RawID + ")");
             
             block = def.GetBlock();
             BlockDefinition.Add(def, defs, lvl);

--- a/MCGalaxy/Commands/Chat/CmdIgnore.cs
+++ b/MCGalaxy/Commands/Chat/CmdIgnore.cs
@@ -51,6 +51,8 @@ namespace MCGalaxy.Commands.Chatting {
                 Toggle(p, ref p.Ignores.DrawOutput, "{0} ignoring draw command output"); return;
             } else if (action == "worldchanges") {
                 Toggle(p, ref p.Ignores.WorldChanges, "{0} ignoring world changes"); return;
+            } else if (action == "blockdefchanges") {
+                Toggle(p, ref p.Ignores.BlockdefChanges, "{0} ignoring block definition messages"); return;
             } else if (IsListCommand(action)) {
                 p.Ignores.Output(p); return;
             }
@@ -113,6 +115,7 @@ namespace MCGalaxy.Commands.Chatting {
             p.Message("&H 8ball - &T/8ball &His ignored.");
             p.Message("&H drawoutput - drawing command output is ignored.");
             p.Message("&H worldchanges - world change messages are ignored.");  
+            p.Message("&H blockdefchanges - block definition messages are ignored.");  
         }
     }
 }

--- a/MCGalaxy/Commands/Fun/CmdLavaSurvival.cs
+++ b/MCGalaxy/Commands/Fun/CmdLavaSurvival.cs
@@ -155,7 +155,8 @@ namespace MCGalaxy.Commands.Fun {
             
             string prop = args[2];
             if (prop.CaselessEq("safe")) {
-                p.Message("Place or break two blocks to determine the edges.");
+                if (!p.Ignores.DrawOutput || !p.Supports(CpeExt.MessageTypes))
+                    p.Message("Place or break two blocks to determine the edges.");
                 p.MakeSelection(2, cfg, SetSafeZone);
                 return;
             }

--- a/MCGalaxy/Commands/Moderation/CmdHighlight.cs
+++ b/MCGalaxy/Commands/Moderation/CmdHighlight.cs
@@ -55,7 +55,8 @@ namespace MCGalaxy.Commands.Moderation {
                 Vec3S32[] marks = new Vec3S32[] { Vec3U16.MinVal, Vec3U16.MaxVal };
                 HighlightPlayer(p, delta, parts[0], ids, marks);
             } else {
-                p.Message("Place or break two blocks to determine the edges.");
+                if (!p.Ignores.DrawOutput || !p.Supports(CpeExt.MessageTypes))
+                    p.Message("Place or break two blocks to determine the edges.");
                 HighlightAreaArgs args = new HighlightAreaArgs();
                 args.ids = ids; args.who = parts[0]; args.delta = delta;
                 p.MakeSelection(2,  "Selecting region for &SHighlight", args, DoHighlightArea);

--- a/MCGalaxy/Commands/Moderation/CmdUndoPlayer.cs
+++ b/MCGalaxy/Commands/Moderation/CmdUndoPlayer.cs
@@ -54,7 +54,8 @@ namespace MCGalaxy.Commands.Moderation {
                 Vec3S32[] marks = new Vec3S32[] { Vec3U16.MinVal, Vec3U16.MaxVal };
                 UndoPlayer(p, delta, names, ids, marks);
             } else {
-                p.Message("Place or break two blocks to determine the edges.");
+                if (!p.Ignores.DrawOutput || !p.Supports(CpeExt.MessageTypes))
+                    p.Message("Place or break two blocks to determine the edges.");
                 UndoAreaArgs args = new UndoAreaArgs();
                 args.ids = ids; args.names = names; args.delta = delta;
                 p.MakeSelection(2, "Selecting region for &SUndo player", args, DoUndoArea);

--- a/MCGalaxy/Commands/Moderation/ZoneCmds.cs
+++ b/MCGalaxy/Commands/Moderation/ZoneCmds.cs
@@ -75,7 +75,8 @@ namespace MCGalaxy.Commands.Moderation {
             if (!PermissionCmd.Do(p, args, offset + 1, false, z.Access, data, p.level)) return;
             
             p.Message("Creating zone " + z.ColoredName);
-            p.Message("Place or break two blocks to determine the edges.");
+            if (!p.Ignores.DrawOutput || !p.Supports(CpeExt.MessageTypes))
+                p.Message("Place or break two blocks to determine the edges.");
             p.MakeSelection(2, "Selecting region for &SNew zone", z, AddZone);
         }
         

--- a/MCGalaxy/Commands/World/CmdBlockProperties.cs
+++ b/MCGalaxy/Commands/World/CmdBlockProperties.cs
@@ -154,7 +154,7 @@ namespace MCGalaxy.Commands.World {
             scope[block] = BlockProps.MakeDefault(scope, p.level, block);
             string name  = BlockProps.ScopedName(scope, p, block);
             
-            if (!p.Ignores.BlockDef)
+            if (!p.Ignores.BlockdefChanges)
                 p.Message("Reset properties of {0} to default", name);
             BlockProps.ApplyChanges(scope, p.level, block, true);
         }

--- a/MCGalaxy/Commands/World/CmdBlockProperties.cs
+++ b/MCGalaxy/Commands/World/CmdBlockProperties.cs
@@ -154,7 +154,8 @@ namespace MCGalaxy.Commands.World {
             scope[block] = BlockProps.MakeDefault(scope, p.level, block);
             string name  = BlockProps.ScopedName(scope, p, block);
             
-            p.Message("Reset properties of {0} to default", name);
+            if (!p.Ignores.BlockDef)
+                p.Message("Reset properties of {0} to default", name);
             BlockProps.ApplyChanges(scope, p.level, block, true);
         }
         

--- a/MCGalaxy/Commands/building/CmdCenter.cs
+++ b/MCGalaxy/Commands/building/CmdCenter.cs
@@ -27,7 +27,8 @@ namespace MCGalaxy.Commands.Building {
         public override string type { get { return CommandTypes.Building; } }
         
         public override void Use(Player p, string message, CommandData data) {
-            p.Message("Place or break two blocks to determine the edges.");
+            if (!p.Ignores.DrawOutput || !p.Supports(CpeExt.MessageTypes))
+                p.Message("Place or break two blocks to determine the edges.");
             p.MakeSelection(2, "Selecting region for &SCenter", null, DoCentre);
         }
         

--- a/MCGalaxy/Commands/building/CmdCopy.cs
+++ b/MCGalaxy/Commands/building/CmdCopy.cs
@@ -90,7 +90,8 @@ namespace MCGalaxy.Commands.Building {
                 }
             }
 
-            p.Message("Place or break two blocks to determine the edges.");
+            if (!p.Ignores.DrawOutput || !p.Supports(CpeExt.MessageTypes))
+                p.Message("Place or break two blocks to determine the edges.");
             int marks = cArgs.offsetIndex != -1 ? 3 : 2;
             p.MakeSelection(marks, "Selecting region for &SCopy", cArgs, DoCopy, DoCopyMark);
         }

--- a/MCGalaxy/Commands/building/CmdDrill.cs
+++ b/MCGalaxy/Commands/building/CmdDrill.cs
@@ -32,7 +32,8 @@ namespace MCGalaxy.Commands.Building {
             ushort dist = 20;
             if (message.Length > 0 && !CommandParser.GetUShort(p, message, "Distance", ref dist)) return;
             
-            p.Message("Destroy the block you wish to drill.");
+            if (!p.Ignores.DrawOutput || !p.Supports(CpeExt.MessageTypes))
+                p.Message("Destroy the block you wish to drill.");
             p.MakeSelection(1, "Selecting location for &SDrill", dist, DoDrill);
         }
         

--- a/MCGalaxy/Commands/building/CmdImageprint.cs
+++ b/MCGalaxy/Commands/building/CmdImageprint.cs
@@ -83,7 +83,8 @@ namespace MCGalaxy.Commands.Building {
                 dArgs.Data = File.ReadAllBytes(path);
             }
 
-            p.Message("Place or break two blocks to determine direction.");
+            if (!p.Ignores.DrawOutput || !p.Supports(CpeExt.MessageTypes))
+                p.Message("Place or break two blocks to determine direction.");
             p.MakeSelection(2, "Selecting direction for &SImagePrint", dArgs, DoImage);
         }
         

--- a/MCGalaxy/Commands/building/CmdMeasure.cs
+++ b/MCGalaxy/Commands/building/CmdMeasure.cs
@@ -36,7 +36,8 @@ namespace MCGalaxy.Commands.Building {
                 }
             }
             
-            p.Message("Place or break two blocks to determine the edges.");
+            if (!p.Ignores.DrawOutput || !p.Supports(CpeExt.MessageTypes))
+                p.Message("Place or break two blocks to determine the edges.");
             p.MakeSelection(2, "Selecting region for &SMeasure", toCount, DoMeasure);
         }
         

--- a/MCGalaxy/Commands/building/CmdRestartPhysics.cs
+++ b/MCGalaxy/Commands/building/CmdRestartPhysics.cs
@@ -36,7 +36,8 @@ namespace MCGalaxy.Commands.Building {
             message = message.ToLower();
             if (message.Length > 0 && !ParseArgs(p, message, ref extraInfo)) return;
 
-            p.Message("Place or break two blocks to determine the edges.");
+            if (!p.Ignores.DrawOutput || !p.Supports(CpeExt.MessageTypes))
+                p.Message("Place or break two blocks to determine the edges.");
             p.MakeSelection(2, "Selecting region for &SRestart physics", extraInfo, DoRestart);
         }
         

--- a/MCGalaxy/Commands/building/DrawCmd.cs
+++ b/MCGalaxy/Commands/building/DrawCmd.cs
@@ -42,7 +42,8 @@ namespace MCGalaxy.Commands.Building {
             BrushArgs bArgs = new BrushArgs(p, dArgs.BrushArgs, dArgs.Block);
             if (!factory.Validate(bArgs)) return;
             
-            p.Message(PlaceMessage);
+            if (!p.Ignores.DrawOutput || !p.Supports(CpeExt.MessageTypes))
+                p.Message(PlaceMessage);
             p.MakeSelection(MarksCount, "Selecting " + SelectionType + " for &S" + dArgs.Op.Name, dArgs, DoDraw);
         }
         

--- a/MCGalaxy/Player/PlayerIgnores.cs
+++ b/MCGalaxy/Player/PlayerIgnores.cs
@@ -23,7 +23,7 @@ namespace MCGalaxy {
     
     public class PlayerIgnores {
         public List<string> Names = new List<string>(), IRCNicks = new List<string>();
-        public bool All, IRC, Titles, Nicks, EightBall, DrawOutput, WorldChanges;
+        public bool All, IRC, Titles, Nicks, EightBall, DrawOutput, WorldChanges, BlockdefChanges;
         
         public void Load(Player p) {
             string path = "ranks/ignore/" + p.name + ".txt";
@@ -42,6 +42,7 @@ namespace MCGalaxy {
                     if (line == "&8ball") { EightBall = true; continue; }
                     if (line == "&drawoutput") { DrawOutput = true; continue; }
                     if (line == "&worldchanges") { WorldChanges = true; continue; }
+                    if (line == "&blockdefchanges") { BlockdefChanges = true; continue; }
                     
                     if (line.StartsWith("&irc_")) {
                         IRCNicks.Add(line.Substring("&irc_".Length));
@@ -75,6 +76,7 @@ namespace MCGalaxy {
                     if (EightBall) w.WriteLine("&8ball");                    
                     if (DrawOutput) w.WriteLine("&drawoutput");
                     if (WorldChanges) w.WriteLine("&worldchanges");
+                    if (BlockdefChanges) w.WriteLine("&blockdefchanges");
                     
                     foreach (string nick in IRCNicks) { w.WriteLine("&irc_" + nick); }
                     foreach (string name in Names) { w.WriteLine(name); }
@@ -85,7 +87,7 @@ namespace MCGalaxy {
         }
         
         public void Output(Player p) {
-            bool Nothing = !(All|IRC|Titles|Nicks|EightBall|DrawOutput|WorldChanges);
+            bool Nothing = !(All|IRC|Titles|Nicks|EightBall|DrawOutput|WorldChanges|BlockdefChanges);
             if (Names.Count > 0) {
                 Nothing = false;
                 p.Message("&cCurrently ignoring the following players:");
@@ -106,6 +108,7 @@ namespace MCGalaxy {
             if (EightBall) p.Message("&cIgnoring &T/8ball");            
             if (DrawOutput) p.Message("&cIgnoring draw command output");           
             if (WorldChanges) p.Message("&cIgnoring world change messages");
+            if (BlockdefChanges) p.Message("&cIgnoring block definition messages");
 
             if (Nothing) p.Message("&cIgnoring nothing and nobody");
         }

--- a/MCGalaxy/Player/PlayerIgnores.cs
+++ b/MCGalaxy/Player/PlayerIgnores.cs
@@ -85,11 +85,14 @@ namespace MCGalaxy {
         }
         
         public void Output(Player p) {
+            bool Nothing = !(All|IRC|Titles|Nicks|EightBall|DrawOutput|WorldChanges);
             if (Names.Count > 0) {
+                Nothing = false;
                 p.Message("&cCurrently ignoring the following players:");
                 p.Message(Names.Join(n => p.FormatNick(n)));
             }
             if (IRCNicks.Count > 0) {
+                Nothing = false;
                 p.Message("&cCurrently ignoring the following IRC nicks:");
                 p.Message(IRCNicks.Join());
             }
@@ -103,6 +106,8 @@ namespace MCGalaxy {
             if (EightBall) p.Message("&cIgnoring &T/8ball");            
             if (DrawOutput) p.Message("&cIgnoring draw command output");           
             if (WorldChanges) p.Message("&cIgnoring world change messages");
+
+            if (Nothing) p.Message("&cIgnoring nothing and nobody");
         }
     }
 }


### PR DESCRIPTION

Three commits ...
The first adds `/ignore none` to untick all flag style ignores.
The second adds a message to `/ignore list` if you're ignoring nothing what so ever.

The third adds more messages to the list suppressed by Ignores.DrawOutput in the classes:

    Already shown by prompt.
        "Place or break two blocks to determine the edges."

    No news is good news.
        "Created a new " + scope + " custom block"...
        "Duplicated the {0} custom block "...
        "Copied the {0} custom block "...

    Some errors where the end results is what you wanted anyway are suppressed,  
    For example, a missing block definition for block definition remove command is not show.

