### PR TITLE
Fix wonky pyramids

### DIFF
--- a/MCGalaxy/Drawing/DrawOps/AdvConeDrawOps.cs
+++ b/MCGalaxy/Drawing/DrawOps/AdvConeDrawOps.cs
@@ -48,7 +48,7 @@ namespace MCGalaxy.Drawing.Ops {
                 int curHeight = Invert ? yy : height - yy;
                 if (curHeight == 0) continue;
                 
-                double curRadius = Radius * ((double)curHeight / (double)height);
+                double curRadius = Radius * (double)curHeight / (double)height;
                 int dist = xx * xx + zz * zz;
                 if (dist > curRadius * curRadius) continue;               
                 output(Place(x, y, z, brush));
@@ -80,7 +80,7 @@ namespace MCGalaxy.Drawing.Ops {
                 int curHeight = Invert ? yy : height - yy;
                 if (curHeight == 0) continue;
                 
-                double curRadius = Radius * ((double)curHeight / (double)height);
+                double curRadius = Radius * (double)curHeight / (double)height;
                 int dist = xx * xx + zz * zz;
                 if (dist > curRadius * curRadius || dist < (curRadius - 1) * (curRadius - 1)) continue;              
                 output(Place(x, y, z, brush));
@@ -109,7 +109,7 @@ namespace MCGalaxy.Drawing.Ops {
                 int curHeight = height - yy;
                 if (curHeight == 0) continue;
                 
-                double curRadius = Radius * ((double)curHeight / (double)height);
+                double curRadius = Radius * (double)curHeight / (double)height;
                 int dist = xx * xx + zz * zz;
                 if (dist > curRadius * curRadius) continue;
                 

--- a/MCGalaxy/Drawing/DrawOps/AdvConeDrawOps.cs
+++ b/MCGalaxy/Drawing/DrawOps/AdvConeDrawOps.cs
@@ -48,7 +48,7 @@ namespace MCGalaxy.Drawing.Ops {
                 int curHeight = Invert ? yy : height - yy;
                 if (curHeight == 0) continue;
                 
-                double curRadius = Radius * (double)curHeight / (double)height;
+                int curRadius = Radius * curHeight / height;
                 int dist = xx * xx + zz * zz;
                 if (dist > curRadius * curRadius) continue;               
                 output(Place(x, y, z, brush));
@@ -80,9 +80,12 @@ namespace MCGalaxy.Drawing.Ops {
                 int curHeight = Invert ? yy : height - yy;
                 if (curHeight == 0) continue;
                 
-                double curRadius = Radius * (double)curHeight / (double)height;
+                int curRadius = Radius * curHeight / height;
+                int curRadius2 = Radius * (curHeight-1) / height;
                 int dist = xx * xx + zz * zz;
-                if (dist > curRadius * curRadius || dist < (curRadius - 1) * (curRadius - 1)) continue;              
+                if (dist > curRadius * curRadius ||
+                    (dist <= (curRadius - 1) * (curRadius - 1) &&
+                     dist <= (curRadius2) * (curRadius2) )) continue;
                 output(Place(x, y, z, brush));
             }
         }
@@ -109,11 +112,16 @@ namespace MCGalaxy.Drawing.Ops {
                 int curHeight = height - yy;
                 if (curHeight == 0) continue;
                 
-                double curRadius = Radius * (double)curHeight / (double)height;
+                int curRadius = Radius * curHeight / height;
+                int curRadius2 = Radius * (curHeight-1) / height;
                 int dist = xx * xx + zz * zz;
                 if (dist > curRadius * curRadius) continue;
                 
-                bool layer = dist >= (curRadius - 1) * (curRadius - 1);
+                bool layer =
+                   !(dist <= (curRadius - 1) * (curRadius - 1) &&
+                     dist <= (curRadius2) * (curRadius2) )
+                     || curRadius == 0;
+
                 BlockID block = layer ? Block.Grass : Block.StillLava;
                 output(Place(x, y, z, block));
             }

--- a/MCGalaxy/Drawing/DrawOps/AdvPyramidDrawOps.cs
+++ b/MCGalaxy/Drawing/DrawOps/AdvPyramidDrawOps.cs
@@ -79,9 +79,11 @@ namespace MCGalaxy.Drawing.Ops {
                 if (curHeight == 0) continue;
                 
                 int curRadius = Radius * curHeight / height;
+                int curRadius2 = Radius * (curHeight-1) / height;
                 int absx = Math.Abs(xx), absz = Math.Abs(zz);
                 if (absx > curRadius || absz > curRadius) continue;
-                if (absx < (curRadius - 1) && absz < (curRadius - 1)) continue;
+                if (absx <= (curRadius - 1) && absz <= (curRadius - 1) &&
+                    absx <= (curRadius2) && absz <= (curRadius2)) continue;
                 output(Place(x, y, z, brush));
             }
         }

--- a/MCGalaxy/Drawing/DrawOps/AdvPyramidDrawOps.cs
+++ b/MCGalaxy/Drawing/DrawOps/AdvPyramidDrawOps.cs
@@ -47,7 +47,7 @@ namespace MCGalaxy.Drawing.Ops {
                 int curHeight = Invert ? yy : height - yy;
                 if (curHeight == 0) continue;              
                 
-                double curRadius = Radius * ((double)curHeight / (double)height);
+                int curRadius = Radius * curHeight / height;
                 if (Math.Abs(xx) > curRadius || Math.Abs(zz) > curRadius) continue;            
                 output(Place(x, y, z, brush));
             }
@@ -78,7 +78,7 @@ namespace MCGalaxy.Drawing.Ops {
                 int curHeight = Invert ? yy : height - yy;
                 if (curHeight == 0) continue;
                 
-                double curRadius = Radius * ((double)curHeight / (double)height);
+                int curRadius = Radius * curHeight / height;
                 int absx = Math.Abs(xx), absz = Math.Abs(zz);
                 if (absx > curRadius || absz > curRadius) continue;
                 if (absx < (curRadius - 1) && absz < (curRadius - 1)) continue;


### PR DESCRIPTION
Previously the slope of the pyramid was cast into a double.
A double will round any ratio that is not exactly representable by a short non-repeating binary fraction.
This change keeps the value as an exact rational and only uses the double type where intermediate values may exceed the integer range.

The result is that large pyramids and cones no longer have any kinks in the slopes.
