### PR TITLE
Add text property to zones

### DIFF
--- a/MCGalaxy/Commands/Moderation/ZoneCmds.cs
+++ b/MCGalaxy/Commands/Moderation/ZoneCmds.cs
@@ -21,6 +21,7 @@ using MCGalaxy.Commands.CPE;
 using MCGalaxy.Commands.World;
 using MCGalaxy.Events.PlayerEvents;
 using MCGalaxy.Maths;
+using MCGalaxy.Blocks.Extended;
 using BlockID = System.UInt16;
 
 namespace MCGalaxy.Commands.Moderation {
@@ -134,6 +135,15 @@ namespace MCGalaxy.Commands.Moderation {
             } else if (opt.CaselessEq("motd")) {
                 zone.Config.MOTD = value;
                 OnChangedZone(zone);
+            } else if (opt.CaselessEq("text")) {
+                if (value == "null") {
+                    zone.Config.Text = "";
+                } else {
+                    bool allCmds = HasExtraPerm(p, "MB", p.Rank, 1);
+                    if (!MessageBlock.Validate(p, value, allCmds)) return;
+                    zone.Config.Text = value;
+                    OnChangedZone(zone);
+                }
             } else if (CmdEnvironment.Handle(p, p.level, opt, value, zone.Config, "zone " + zone.ColoredName)) {
                 OnChangedZone(zone);
             } else {
@@ -170,6 +180,9 @@ namespace MCGalaxy.Commands.Moderation {
                 p.Message("&HSets the color of the box shown around the zone");
                 p.Message("&T/Zone set [name] motd [value]");
                 p.Message("&HSets the MOTD applied when in the zone. See &T/Help map motd");
+                p.Message("&T/Zone set [name] text [text]");
+                p.Message("&HSets the text shown when a player enters the zone.");
+                p.Message("&HSee &T/Help mb. &HUse \"null\" to remove the text");
                 p.Message("&T/Zone set [name] [env property] [value]");
                 p.Message("&HSets an env setting applied when in the zone. See &T/Help env");
             } else {

--- a/MCGalaxy/CorePlugin/MiscHandlers.cs
+++ b/MCGalaxy/CorePlugin/MiscHandlers.cs
@@ -64,13 +64,18 @@ namespace MCGalaxy.Core {
             }
         }
 		
-		internal static void HandleChangedZone(Player p) {
-			if (p.Supports(CpeExt.InstantMOTD)) p.SendMapMotd();
+        internal static void HandleChangedZone(Player p) {
+            if (p.Supports(CpeExt.InstantMOTD)) p.SendMapMotd();
             p.SendCurrentEnv();
             
             if (p.isFlying && !Hacks.CanUseFly(p)) {
-                p.Message("You cannot use &T/Fly &Son this map.");
+                p.Message("You cannot use &T/Fly &Sin this zone.");
                 p.isFlying = false;
+            }
+
+            Zone zone = p.ZoneIn;
+            if (zone != null && zone.Config.Text != "") {
+                MessageBlock.Execute(p, zone.Config.Text, p.Pos.FeetBlockCoords);
             }
         }
         

--- a/MCGalaxy/CorePlugin/MiscHandlers.cs
+++ b/MCGalaxy/CorePlugin/MiscHandlers.cs
@@ -69,7 +69,7 @@ namespace MCGalaxy.Core {
             p.SendCurrentEnv();
             
             if (p.isFlying && !Hacks.CanUseFly(p)) {
-                p.Message("You cannot use &T/Fly &Sin this zone.");
+                p.Message("You cannot use &T/Fly &Son this map.");
                 p.isFlying = false;
             }
 

--- a/MCGalaxy/Levels/Zone.cs
+++ b/MCGalaxy/Levels/Zone.cs
@@ -31,7 +31,8 @@ namespace MCGalaxy {
         public string ShowColor = "000000";
         [ConfigInt("ShowAlpha", "General", 0, 0, 255)]
         public int ShowAlpha = 0;
-        
+        [ConfigString("Text", "General", "", true)]
+        public string Text = "";
         public string Color { get { return Group.GetColor(BuildMin); } }
     }
     


### PR DESCRIPTION
Adds a "text" property to zones, which works like mbs and /bot text. Triggers when the player enters a zone

I wasn't really sure how to handle removing the text property with /zone set so right now entering "null" removes it. Probably should have a better way of doing it