### PR TITLE
Better parsing for /map authors/realmowner

### DIFF
--- a/MCGalaxy/Levels/LevelOptions.cs
+++ b/MCGalaxy/Levels/LevelOptions.cs
@@ -102,7 +102,7 @@ namespace MCGalaxy {
         }
         
         static void SetOwner(Player p, Level lvl, string value) {
-            lvl.Config.RealmOwner = value.Replace(' ', ',');
+            lvl.Config.RealmOwner = value.Replace(", ", ",").Replace(" ", ",");
             if (value.Length == 0) p.Message("Removed realm owner for this level.");
             else p.Message("Set realm owner/owners of this level to {0}.", value);
         }

--- a/MCGalaxy/Levels/LevelOptions.cs
+++ b/MCGalaxy/Levels/LevelOptions.cs
@@ -203,7 +203,7 @@ namespace MCGalaxy {
         }
         
         static void SetAuthors(Player p, Level lvl, string value) {
-            lvl.Config.Authors = value.Replace(" ", "&S, ");
+            lvl.Config.Authors = value.Replace(", ", ",").Replace(" ", ",");
             p.Message("Map authors set to: &b" + lvl.Config.Authors);
         }
         


### PR DESCRIPTION
Current behaviour:
`/map main authors person1, person2` sets the authors to `person1,&S, person2`
`/map main authors person1 person2` sets the authors to `person1&S, person2`

Both of these behaviours are wrong, as they add colours codes to the authors which breaks LS/ZS map rating commands. Currently the only way to set the authors properly is `/map main authors person1,person2`

New behaviour:
`/map main authors person1, person2`, `/map main authors person1 person2` and `person1,person2` all set the authors to `person1,person2`