### PR TITLE
Add support for the new announcement types

### DIFF
--- a/MCGalaxy/Player/Player.CPE.cs
+++ b/MCGalaxy/Player/Player.CPE.cs
@@ -230,7 +230,7 @@ namespace MCGalaxy {
     public enum CpeMessageType : byte {
         Normal = 0, Status1 = 1, Status2 = 2, Status3 = 3,
         BottomRight1 = 11, BottomRight2 = 12, BottomRight3 = 13,
-        Announcement = 100,
+        Announcement = 100, BigAnnouncement = 101, SmallAnnouncement = 102,
     }
     
     public enum EnvProp : byte {


### PR DESCRIPTION
Since support for new announcement types was added to ClassiCube, I made them possible to use in MCGalaxy too.

Tested with [this mess of a custom command](https://pastebin.com/raw/xuHfQYk4), seems to work.

![screenshot_2021-06-18-13-10-27](https://user-images.githubusercontent.com/78485915/122565974-90bc4100-d036-11eb-8e1c-0c1b2a2736a2.png)
