### PR TITLE
Water changes including #618

### DIFF
--- a/MCGalaxy/Blocks/Physics/AirPhysics.cs
+++ b/MCGalaxy/Blocks/Physics/AirPhysics.cs
@@ -73,8 +73,9 @@ namespace MCGalaxy.Blocks.Physics {
         
         static void FloodAir(Level lvl, ushort x, ushort y, ushort z, BlockID block) {
             int index;
-            BlockID curBlock = Block.Convert(lvl.GetBlock(x, y, z, out index));
-            if (curBlock == Block.Water || curBlock == Block.Lava) {
+            BlockID curBlock = lvl.GetBlock(x, y, z, out index);
+            if (curBlock == Block.WaterDown || curBlock == Block.FiniteWater ||
+                curBlock == Block.LavaDown || curBlock == Block.FiniteLava ) {
                 lvl.AddUpdate(index, block);
             }
         }

--- a/MCGalaxy/Blocks/Physics/ExtLiquidPhysics.cs
+++ b/MCGalaxy/Blocks/Physics/ExtLiquidPhysics.cs
@@ -116,6 +116,8 @@ namespace MCGalaxy.Blocks.Physics {
                 case Block.Air_FloodDown:
                 case Block.StillLava:
                 case Block.StillWater:
+                case Block.Lava:
+                case Block.Water:
                 case Block.WaterDown:
                     break;
                     
@@ -144,6 +146,8 @@ namespace MCGalaxy.Blocks.Physics {
                 case Block.Air_FloodDown:
                 case Block.StillLava:
                 case Block.StillWater:
+                case Block.Lava:
+                case Block.Water:
                 case Block.LavaDown:
                     break;
                 default:

--- a/MCGalaxy/Blocks/Physics/FinitePhysics.cs
+++ b/MCGalaxy/Blocks/Physics/FinitePhysics.cs
@@ -32,9 +32,11 @@ namespace MCGalaxy.Blocks.Physics {
             if (below == Block.Air) {
                 lvl.AddUpdate(index, C.Block, C.Data);
                 lvl.AddUpdate(C.Index, Block.Air, default(PhysicsArgs));
+                CheckAround(lvl, x, y, z, index);
                 C.Data.ResetTypes();
             } else if (below == Block.StillWater || below == Block.StillLava) {
                 lvl.AddUpdate(C.Index, Block.Air, default(PhysicsArgs));
+                CheckAround(lvl, x, y, z, index);
                 C.Data.ResetTypes();
             } else {
                 const int count = 25;
@@ -69,14 +71,34 @@ namespace MCGalaxy.Blocks.Physics {
 
                         if (lvl.IsAirAt(posX, y, posZ, out index) && lvl.AddUpdate(index, C.Block, C.Data)) {
                             lvl.AddUpdate(C.Index, Block.Air, default(PhysicsArgs));
+                            CheckAround(lvl, x, y, z, index);
                             C.Data.ResetTypes();
                             return;
                         }
                     }
                 }
+
+                // Not moving - don't retry.
+                C.Data.Data = PhysicsArgs.RemoveFromChecks;
             }
         }
-        
+
+        static void CheckAround(Level lvl, ushort x, ushort y, ushort z, int newind) {
+            int index, dx, dy, dz;
+            for (dx = -2; dx<3; dx++)
+                for (dy = -2; dy<3; dy++)
+                    for (dz = -2; dz<3; dz++)
+                    {
+                        if (dx==0 && dy==0 && dz==0) continue;
+
+                        BlockID block = lvl.GetBlock((ushort)(x+dx), (ushort)(y+dy), (ushort)(z+dz), out index);
+                        if (index == newind) continue;
+
+                        if (block == Block.FiniteWater || block == Block.FiniteLava)
+                            lvl.AddCheck(index);
+                    }
+        }
+
         static bool Expand(Level lvl, ushort x, ushort y, ushort z) {
             int index;
             return lvl.IsAirAt(x, y, z, out index) && lvl.AddUpdate(index, Block.FiniteWater, default(PhysicsArgs));

--- a/MCGalaxy/Blocks/Physics/SimpleLiquidPhysics.cs
+++ b/MCGalaxy/Blocks/Physics/SimpleLiquidPhysics.cs
@@ -25,8 +25,13 @@ namespace MCGalaxy.Blocks.Physics {
         
         public static void DoWater(Level lvl, ref PhysInfo C) {
             if (lvl.Config.FiniteLiquids) {
-                ushort y = C.Y;
-                if (y >= lvl.Config.EdgeLevel || !lvl.Config.EdgeWater) {
+                if (lvl.Config.FiniteHighWater) {
+                    ushort y = C.Y;
+                    if (y >= lvl.Config.EdgeLevel) {
+                        FinitePhysics.DoWaterOrLava(lvl, ref C);
+                        return;
+                    }
+                } else {
                     FinitePhysics.DoWaterOrLava(lvl, ref C);
                     return;
                 }

--- a/MCGalaxy/Blocks/Physics/SimpleLiquidPhysics.cs
+++ b/MCGalaxy/Blocks/Physics/SimpleLiquidPhysics.cs
@@ -25,8 +25,13 @@ namespace MCGalaxy.Blocks.Physics {
         
         public static void DoWater(Level lvl, ref PhysInfo C) {
             if (lvl.Config.FiniteLiquids) {
-                FinitePhysics.DoWaterOrLava(lvl, ref C);
-            } else if (lvl.Config.RandomFlow) {
+                ushort y = C.Y;
+                if (y >= lvl.Config.EdgeLevel || !lvl.Config.EdgeWater) {
+                    FinitePhysics.DoWaterOrLava(lvl, ref C);
+                    return;
+                }
+            }
+            if (lvl.Config.RandomFlow) {
                 DoWaterRandowFlow(lvl, ref C);
             } else {
                 DoWaterUniformFlow(lvl, ref C);

--- a/MCGalaxy/Commands/World/CmdMap.cs
+++ b/MCGalaxy/Commands/World/CmdMap.cs
@@ -91,6 +91,8 @@ namespace MCGalaxy.Commands.World {
             p.Message("&TPhysics settings:");
             p.Message("  Finite mode: {0}&S, Random flow: {1}",
                            GetBool(cfg.FiniteLiquids), GetBool(cfg.RandomFlow));
+            p.Message("  Finite high water {0}&S",
+                           GetBool(cfg.FiniteHighWater));
             p.Message("  Animal hunt AI: {0}&S, Edge water: {1}",
                            GetBool(cfg.AnimalHuntAI), GetBool(cfg.EdgeWater));
             p.Message("  Grass growing: {0}&S, {1} tree growing: {2}",

--- a/MCGalaxy/Levels/LevelConfig.cs
+++ b/MCGalaxy/Levels/LevelConfig.cs
@@ -233,6 +233,8 @@ namespace MCGalaxy {
         public bool LeafDecay;
         [ConfigBool("Finite mode", "Physics", false)]
         public bool FiniteLiquids;
+        [ConfigBool("FiniteHighWater", "Physics", false)]
+        public bool FiniteHighWater;
         [ConfigBool("GrowTrees", "Physics", false)]
         public bool GrowTrees;
         [ConfigBool("Animal AI", "Physics", true)]

--- a/MCGalaxy/Levels/LevelOptions.cs
+++ b/MCGalaxy/Levels/LevelOptions.cs
@@ -39,6 +39,7 @@ namespace MCGalaxy {
         public const string Goto = "LoadOnGoto", Decay = "LeafDecay", Flow = "RandomFlow", Trees = "GrowTrees";
         public const string Chat = "Chat", Guns = "Guns", Buildable = "Buildable", Deletable = "Deletable";
         public const string LoadDelay = "LoadDelay", Drawing = "Drawing", Authors = "Authors";
+        public const string FiniteHighWater = "FiniteHighWater";
         
         public static List<LevelOption> Options = new List<LevelOption>() {
              new LevelOption(MOTD,       SetMotd,  "&HSets the motd for this map. (leave blank to use default motd)"),
@@ -51,6 +52,7 @@ namespace MCGalaxy {
              new LevelOption(Fall,   SetFall,   "&HSets how many blocks you can fall before dying."),
              new LevelOption(Drown,  SetDrown,  "&HSets how long you can stay underwater (in tenths of a second) before drowning."),
              new LevelOption(Finite, SetFinite, "&HWhether all liquids are finite."),
+             new LevelOption(FiniteHighWater, SetFiniteHighWater, "&HWhether Only active water above edge level is finite."),
              new LevelOption(AI,     SetAI,     "&HAI will make animals hunt or flee."),
              new LevelOption(Edge,   SetEdge,   "&HWhether water flows from the map edges."),
              new LevelOption(Grass,  SetGrass,  "&HWhether grass auto grows or not."),
@@ -126,6 +128,7 @@ namespace MCGalaxy {
         }
         
         static void SetFinite(Player p, Level l, string v) { Toggle(p, l, ref l.Config.FiniteLiquids, "Finite mode"); }
+        static void SetFiniteHighWater(Player p, Level l, string v) { Toggle(p, l, ref l.Config.FiniteHighWater, "FiniteHighWater"); }
         static void SetAI(Player p,     Level l, string v) { Toggle(p, l, ref l.Config.AnimalHuntAI, "Animal AI"); }
         static void SetEdge(Player p,   Level l, string v) { Toggle(p, l, ref l.Config.EdgeWater, "Edge water"); }
         static void SetGrass(Player p,  Level l, string v) { Toggle(p, l, ref l.Config.GrassGrow, "Growing grass"); }


### PR DESCRIPTION
These three commits
* Fix the "flashing water" issue (Where alternate ticks can toggle large volumes of ActiveWater) with a Water faucet hitting ActiveWater with AirFloodDown.
* Fix the CPU issue with finitewater not removing Physics entries #618
* Add a new feature to have finite water above the EdgeLevel and ActiveWater below.

With the last one I note that EdgeWater is a bit lame when combined with FiniteLiquids.
So If both of these flags are set on a map the FiniteLiquids applies always to ActiveLava and to ActiveWater above the edge level. Below the Edge level ActiveWater ignores the FiniteLiquids flag and goes with Flood semantics. This allows flooding of underwater/underground bases but prevents flooding of the overworld.

(Not withstanding my opinion on finite EdgeWater you may want to put this on a distinct Option/property)

The *Faucet fix might make the WaterFaucet suitable for guest access as the block now appears to have no difficult to reverse effects. 

Note these commit's can be merged individually if you prefer.
