### PR TITLE
Don't steal players money if they try to buy things while muted

### DIFF
--- a/MCGalaxy/Economy/MessageItems.cs
+++ b/MCGalaxy/Economy/MessageItems.cs
@@ -35,6 +35,11 @@ namespace MCGalaxy.Eco {
                 return;
             }
             
+            if (p.muted) {
+                p.Message("%WYou cannot purchase this while you are muted.");
+                return;
+            }
+
         	if (!CheckPrice(p)) return;
             if (msg == PlayerDB.GetLoginMessage(p)) {
                 p.Message("&WYou already have that login message."); return;
@@ -62,6 +67,11 @@ namespace MCGalaxy.Eco {
                 p.Message("&aYour logout message was removed for free.");
                 return;
         	}
+            
+            if (p.muted) {
+                p.Message("%WYou cannot purchase this while you are muted.");
+                return;
+            }
             
         	if (!CheckPrice(p)) return;    
             if (msg == PlayerDB.GetLogoutMessage(p)) {

--- a/MCGalaxy/Economy/NameItems.cs
+++ b/MCGalaxy/Economy/NameItems.cs
@@ -29,8 +29,13 @@ namespace MCGalaxy.Eco {
         
         protected internal override void OnPurchase(Player p, string title) {
             if (title.Length == 0) {
-                UseCommand(p, "Title", "-own");
+                UseCommand(Player.Console, "Title", p.name);
                 p.Message("&aYour title was removed for free."); return;
+            }
+
+            if (p.muted) {
+                p.Message("%WYou cannot purchase this while you are muted.");
+                return;
             }
             
         	if (!CheckPrice(p)) return;
@@ -56,8 +61,13 @@ namespace MCGalaxy.Eco {
         
         protected internal override void OnPurchase(Player p, string nick) {
             if (nick.Length == 0) {
-                UseCommand(p, "Nick", "-own");
+                UseCommand(Player.Console, "Nick", p.name);
                 p.Message("&aYour nickname was removed for free."); return;
+            }
+            
+            if (p.muted) {
+                p.Message("%WYou cannot purchase this while you are muted.");
+                return;
             }
             
         	if (!CheckPrice(p)) return;


### PR DESCRIPTION
Instead of taking the money and then telling the player they can't for example use /nick while muted, check if the player is muted beforehand. 

`UseCommand(Player.Console` is used when resetting nick/title, since muted players should still probably be able to remove those.