### PR TITLE
Docker support for CLI project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+FROM mcr.microsoft.com/dotnet/sdk:3.1 AS build-env
+WORKDIR /app
+
+# Copy csproj and restore as distinct layers
+COPY ./MCGalaxy/MCGalaxy_core.csproj /MCGalaxy/MCGalaxy_core.csproj
+COPY ./CLI/MCGalaxyCLI_core.csproj MCGalaxyCLI_core.csproj
+
+RUN dotnet restore
+
+# Copy everything else and build
+COPY ./MCGalaxy /MCGalaxy 
+COPY ./CLI/Program.cs /app
+
+RUN ls -la
+
+RUN dotnet build -c Release
+RUN dotnet publish --no-build -c Release -o out 
+
+# Build runtime image
+FROM mcr.microsoft.com/dotnet/runtime:3.1 AS local-run-env
+WORKDIR /app
+
+RUN apt-get -y update
+RUN apt-get -y upgrade
+RUN apt-get install -y sqlite3 libsqlite3-dev
+
+COPY --from=build-env /app/out /app
+
+ENTRYPOINT ["dotnet", "MCGalaxyCLI_core.dll"]
+
+EXPOSE 25565

--- a/MCGalaxy/Commands/Bots/CmdBotWhere.cs
+++ b/MCGalaxy/Commands/Bots/CmdBotWhere.cs
@@ -1,0 +1,47 @@
+﻿/*
+    Copyright 2015 MCGalaxy
+    
+    Dual-licensed under the Educational Community License, Version 2.0 and
+    the GNU General Public License, Version 3 (the "Licenses"); you may
+    not use this file except in compliance with the Licenses. You may
+    obtain a copy of the Licenses at
+    
+    http://www.opensource.org/licenses/ecl2.php
+    http://www.gnu.org/licenses/gpl-3.0.html
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the Licenses are distributed on an "AS IS"
+    BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the Licenses for the specific language governing
+    permissions and limitations under the Licenses.
+ */
+using System;
+using MCGalaxy.Games;
+
+namespace MCGalaxy.Commands.Bots {
+    public sealed class CmdBotWhere : Command2 {
+        public override string name { get { return "BotWhere"; } }
+        public override string type { get { return CommandTypes.Information; } }
+        
+        public override void Use(Player p, string message, CommandData data) {
+            if (message.Length == 0) return;
+
+            PlayerBot target = Matcher.FindBots(p, message);
+            if (target == null) return;
+            
+            int x = target.Pos.X, y = target.Pos.Y - Entities.CharacterHeight, z = target.Pos.Z;
+            p.Message("{0} &Sis on {1}", p.FormatNick(target.DisplayName), target.level.ColoredName);
+            p.Message("   X: &b{0:F5} &SY: &b{1:F5} &SZ: &b{2:F5}",
+                           x / 32.0, y / 32.0, z / 32.0);
+            
+            p.Message("   Yaw: &b{0} &Sdegrees, Pitch: &b{1} &Sdegrees",
+                           Orientation.PackedToDegrees(p.Rot.RotY),
+                           Orientation.PackedToDegrees(p.Rot.HeadX));
+        }      
+
+        public override void Help(Player p) {
+            p.Message("&T/BotWhere [name]");
+            p.Message("&HDisplays level, position, and orientation of that bot.");
+        }
+    }
+}


### PR DESCRIPTION
Uses the existing _core projects and compiles them into a Docker container exposing the MCGalaxy server through port 25565. 

Use `docker run -i -p 25565:25565 <image-id>` to run the Docker image locally. The game will be exposed on 127.0.0.1:25565 and the console can be used interactively. 