### PR TITLE
Add support for protocols 3-5

### DIFF
--- a/MCGalaxy/Blocks/Block.Convert.cs
+++ b/MCGalaxy/Blocks/Block.Convert.cs
@@ -102,15 +102,29 @@ namespace MCGalaxy {
             
             // protocol version 6 only supports up to gold block
             switch (block) {
-                case Iron:  return Gold;
-                case DoubleSlab: return Gray;
-                case Slab:  return Gray;
-                case Brick: return Red;
-                case TNT:   return Red;
-                case Bookshelf:  return Wood;
-                case MossyRocks: return Cobblestone;
-                case Obsidian:   return Cobblestone;
+                case Iron:       block = Gold; break;
+                case DoubleSlab: block = Gray; break;
+                case Slab:       block = Gray; break;
+                case Brick:      block = Red; break;
+                case TNT:        block = Red; break;
+                case Bookshelf:  block = Wood; break;
+                case MossyRocks: block = Cobblestone; break;
+                case Obsidian:   block = Cobblestone; break;
             }
+            if (p.version >= Server.VERSION_0020) return block;
+            
+            // protocol version 5 only supports up to glass block
+            if (block == Block.Gold)      block = Block.Sponge;
+            if (block >= Block.Dandelion) block = Block.Sapling;
+            if (block >= Block.Red)       block = Block.Sand;
+            if (p.version >= Server.VERSION_0019) return block;
+            
+            // protocol version 4 only supports up to leaves block
+            if (block == Block.Glass) block  = Block.Leaves;
+            if (block == Block.Sponge) block = Block.GoldOre;
+            
+            // protocol version 3 seems to have support
+            // TODO what even changed between 3 and 4?
             return block;
         }
         

--- a/MCGalaxy/Blocks/Block.Convert.cs
+++ b/MCGalaxy/Blocks/Block.Convert.cs
@@ -80,6 +80,7 @@ namespace MCGalaxy {
         internal static byte ConvertLimited(byte block, Player p) {
         	if (p.hasCustomBlocks) return block;
         	
+            // protocol version 7 only supports up to Obsidian block
             switch (block) {
                 case CobblestoneSlab: block = Slab; break;
                 case Rope:        block = Mushroom; break;
@@ -100,7 +101,7 @@ namespace MCGalaxy {
             }
             if (p.version >= Server.VERSION_0030) return block;
             
-            // protocol version 6 only supports up to gold block
+            // protocol version 6 only supports up to Gold block
             switch (block) {
                 case Iron:       block = Gold; break;
                 case DoubleSlab: block = Gray; break;
@@ -113,17 +114,17 @@ namespace MCGalaxy {
             }
             if (p.version >= Server.VERSION_0020) return block;
             
-            // protocol version 5 only supports up to glass block
+            // protocol version 5 only supports up to Glass block
             if (block == Block.Gold)      block = Block.Sponge;
             if (block >= Block.Dandelion) block = Block.Sapling;
             if (block >= Block.Red)       block = Block.Sand;
             if (p.version >= Server.VERSION_0019) return block;
             
-            // protocol version 4 only supports up to leaves block
+            // protocol version 4 only supports up to Leaves block
             if (block == Block.Glass) block  = Block.Leaves;
             if (block == Block.Sponge) block = Block.GoldOre;
             
-            // protocol version 3 seems to have support
+            // protocol version 3 seems to have same support
             // TODO what even changed between 3 and 4?
             return block;
         }

--- a/MCGalaxy/Network/Packets/Packet.cs
+++ b/MCGalaxy/Network/Packets/Packet.cs
@@ -29,7 +29,8 @@ namespace MCGalaxy.Network
         #region Classic
         
         public static byte[] Motd(Player p, string motd) {
-            byte[] buffer = new byte[131];
+            bool type     = p.version >= Server.VERSION_0023;
+            byte[] buffer = new byte[130 + (type ? 1 : 0)];
             buffer[0] = Opcode.Handshake;
             buffer[1] = p.version;
             
@@ -41,7 +42,7 @@ namespace MCGalaxy.Network
                 NetUtils.Write(motd, buffer, 66, p.hasCP437);
             }
 
-            buffer[130] = p.UserType();
+            if (type) buffer[130] = p.UserType();
             return buffer;
         }
         

--- a/MCGalaxy/Network/Packets/Packet.cs
+++ b/MCGalaxy/Network/Packets/Packet.cs
@@ -29,7 +29,7 @@ namespace MCGalaxy.Network
         #region Classic
         
         public static byte[] Motd(Player p, string motd) {
-            bool type     = p.version >= Server.VERSION_0023;
+            bool type     = p.version >= Server.VERSION_0020;
             byte[] buffer = new byte[130 + (type ? 1 : 0)];
             buffer[0] = Opcode.Handshake;
             buffer[1] = p.version;

--- a/MCGalaxy/Network/Player.Networking.cs
+++ b/MCGalaxy/Network/Player.Networking.cs
@@ -27,10 +27,6 @@ namespace MCGalaxy
 {
     public partial class Player : IDisposable, INetProtocol 
     {
-        public bool hasCpe, finishedCpeLogin;
-        public string appName;
-        int extensionCount;
-        
         int INetProtocol.ProcessReceived(byte[] buffer, int bufferLen) {
             int read = 0;
             try {
@@ -113,36 +109,7 @@ namespace MCGalaxy
             ProcessChat(buffer, offset);
             return size;
         }
-        
-        int HandleExtInfo(byte[] buffer, int offset, int left) {
-            const int size = 1 + 64 + 2;
-            if (left < size) return 0;
-            
-            appName = NetUtils.ReadString(buffer, offset + 1);
-            extensionCount = buffer[offset + 66];
-            CheckReadAllExtensions(); // in case client supports 0 CPE packets
-            return size;
-        }
 
-        int HandleExtEntry(byte[] buffer, int offset, int left) {
-            const int size = 1 + 64 + 4;
-            if (left < size) return 0;
-            
-            string extName = NetUtils.ReadString(buffer, offset + 1);
-            int extVersion = NetUtils.ReadI32(buffer, offset + 65);
-            AddExtension(extName, extVersion);
-            extensionCount--;
-            CheckReadAllExtensions();
-            return size;
-        }
-
-        void CheckReadAllExtensions() {
-            if (extensionCount <= 0 && !finishedCpeLogin) {
-                CompleteLoginProcess();
-                finishedCpeLogin = true;
-            }
-        }
-        
         
         public void Send(byte[] buffer)  { Socket.Send(buffer, SendFlags.None); }
         public void Send(byte[] buffer, bool sync) {

--- a/MCGalaxy/Player/Player.Handlers.cs
+++ b/MCGalaxy/Player/Player.Handlers.cs
@@ -29,8 +29,10 @@ using MCGalaxy.SQL;
 using MCGalaxy.Util;
 using BlockID = System.UInt16;
 
-namespace MCGalaxy {
-    public partial class Player : IDisposable {
+namespace MCGalaxy 
+{
+    public partial class Player : IDisposable 
+    {
         const string mustAgreeMsg = "You must read /rules then agree to them with /agree!";
         
         readonly object blockchangeLock = new object();
@@ -186,9 +188,9 @@ namespace MCGalaxy {
             return result;
         }
 
-        void HandleBlockchange(byte[] buffer, int offset, int left) {
+        void ProcessBlockchange(byte[] buffer, int offset) {
             try {
-                if (!loggedIn || spamChecker.CheckBlockSpam()) return;
+                if (spamChecker.CheckBlockSpam()) return;
                 ushort x = NetUtils.ReadU16(buffer, offset + 1);
                 ushort y = NetUtils.ReadU16(buffer, offset + 3);
                 ushort z = NetUtils.ReadU16(buffer, offset + 5);
@@ -229,8 +231,7 @@ namespace MCGalaxy {
             }
         }
         
-        void HandleMovement(byte[] buffer, int offset, int left) {
-            if (!loggedIn) return;
+        void ProcessMovement(byte[] buffer, int offset) {
             if (trainGrab || following.Length > 0) { CheckBlocks(Pos, Pos); return; }
             if (Supports(CpeExt.HeldBlock)) {
                 ClientHeldBlock = ReadBlock(buffer, offset + 1);
@@ -288,7 +289,10 @@ namespace MCGalaxy {
             if (zone != null) OnChangedZoneEvent.Call(this);
         }        
         
-        void HandlePlayerClicked(byte[] buffer, int offset, int left) {
+        int HandlePlayerClicked(byte[] buffer, int offset, int left) {
+            const int size = 1 + 1 + 1 + 2 + 2 + 1 + 2 + 2 + 2 + 1;
+            if (left < size) return 0;
+            
             MouseButton Button = (MouseButton)buffer[offset + 1];
             MouseAction Action = (MouseAction)buffer[offset + 2];
             ushort yaw = NetUtils.ReadU16(buffer, offset + 3);
@@ -301,9 +305,13 @@ namespace MCGalaxy {
             TargetBlockFace face = (TargetBlockFace)buffer[offset + 14];
             if (face > TargetBlockFace.None) face = TargetBlockFace.None;
             OnPlayerClickEvent.Call(this, Button, Action, yaw, pitch, entityID, x, y, z, face);
+            return size;
         }
         
-        void HandleTwoWayPing(byte[] buffer, int offset, int left) {
+        int HandleTwoWayPing(byte[] buffer, int offset, int left) {
+            const int size = 1 + 1 + 2;
+            if (left < size) return 0;
+            
             bool serverToClient = buffer[offset + 1] != 0;
             ushort data = NetUtils.ReadU16(buffer, offset + 2);
             
@@ -314,6 +322,7 @@ namespace MCGalaxy {
                 // Server -> client ping, set time received for reply.
                 Ping.Update(data);
             }
+            return size;
         }
         
         int CurrentEnvProp(EnvProp i, Zone zone) {
@@ -429,9 +438,8 @@ namespace MCGalaxy {
             lastDeath = DateTime.UtcNow;
             return true;
         }
-
-        void HandleChat(byte[] buffer, int offset, int left) {
-            if (!loggedIn) return;
+        
+        void ProcessChat(byte[] buffer, int offset) {
             byte continued = buffer[offset + 1];
             string text = NetUtils.ReadString(buffer, offset + 2);
             LastAction = DateTime.UtcNow;

--- a/MCGalaxy/Player/Player.Handlers.cs
+++ b/MCGalaxy/Player/Player.Handlers.cs
@@ -186,7 +186,7 @@ namespace MCGalaxy {
             return result;
         }
 
-        void HandleBlockchange(byte[] buffer, int offset) {
+        void HandleBlockchange(byte[] buffer, int offset, int left) {
             try {
                 if (!loggedIn || spamChecker.CheckBlockSpam()) return;
                 ushort x = NetUtils.ReadU16(buffer, offset + 1);
@@ -229,7 +229,7 @@ namespace MCGalaxy {
             }
         }
         
-        void HandleMovement(byte[] buffer, int offset) {
+        void HandleMovement(byte[] buffer, int offset, int left) {
             if (!loggedIn) return;
             if (trainGrab || following.Length > 0) { CheckBlocks(Pos, Pos); return; }
             if (Supports(CpeExt.HeldBlock)) {
@@ -288,7 +288,7 @@ namespace MCGalaxy {
             if (zone != null) OnChangedZoneEvent.Call(this);
         }        
         
-        void HandlePlayerClicked(byte[] buffer, int offset) {
+        void HandlePlayerClicked(byte[] buffer, int offset, int left) {
             MouseButton Button = (MouseButton)buffer[offset + 1];
             MouseAction Action = (MouseAction)buffer[offset + 2];
             ushort yaw = NetUtils.ReadU16(buffer, offset + 3);
@@ -303,7 +303,7 @@ namespace MCGalaxy {
             OnPlayerClickEvent.Call(this, Button, Action, yaw, pitch, entityID, x, y, z, face);
         }
         
-        void HandleTwoWayPing(byte[] buffer, int offset) {
+        void HandleTwoWayPing(byte[] buffer, int offset, int left) {
             bool serverToClient = buffer[offset + 1] != 0;
             ushort data = NetUtils.ReadU16(buffer, offset + 2);
             
@@ -430,7 +430,7 @@ namespace MCGalaxy {
             return true;
         }
 
-        void HandleChat(byte[] buffer, int offset) {
+        void HandleChat(byte[] buffer, int offset, int left) {
             if (!loggedIn) return;
             byte continued = buffer[offset + 1];
             string text = NetUtils.ReadString(buffer, offset + 2);

--- a/MCGalaxy/Player/Player.Login.cs
+++ b/MCGalaxy/Player/Player.Login.cs
@@ -40,12 +40,12 @@ namespace MCGalaxy
             
             LastAction = DateTime.UtcNow;
             version    = buffer[offset + 1];
-            if (version < Server.VERSION_0016 || version > Server.VERSION_0030) {
+            if (version > Server.VERSION_0030) {
                 Leave(null, "Unsupported protocol version", true); return -1; 
             }
             
             // check size now that know whether usertype field is included or not
-            int size = version >= Server.VERSION_0023 ? new_size : old_size;
+            int size = version >= Server.VERSION_0020 ? new_size : old_size;
             if (left < size) return 0;
             if (loggedIn)    return size;
             

--- a/MCGalaxy/Player/Player.Login.cs
+++ b/MCGalaxy/Player/Player.Login.cs
@@ -30,7 +30,7 @@ namespace MCGalaxy
 {
     public partial class Player : IDisposable 
     { 
-        void HandleLogin(byte[] buffer, int offset) {
+        void HandleLogin(byte[] buffer, int offset, int left) {
             LastAction = DateTime.UtcNow;
             if (loggedIn) return;
             version = buffer[offset + 1];

--- a/MCGalaxy/Server/Server.Fields.cs
+++ b/MCGalaxy/Server/Server.Fields.cs
@@ -83,6 +83,9 @@ namespace MCGalaxy {
         public static Scheduler Critical = new Scheduler("MCG_CriticalScheduler");
         public static Server s = new Server();
 
+        public const byte VERSION_0016 = 3; // preclassic 0.0.16
+        public const byte VERSION_0017 = 4; // preclassic 0.0.17 / 0.0.18
+        public const byte VERSION_0019 = 5; // preclassic 0.0.19
         public const byte VERSION_0023 = 6; // preclassic 0.0.23a
         public const byte VERSION_0030 = 7; // classic
         

--- a/MCGalaxy/Server/Server.Fields.cs
+++ b/MCGalaxy/Server/Server.Fields.cs
@@ -86,7 +86,7 @@ namespace MCGalaxy {
         public const byte VERSION_0016 = 3; // preclassic 0.0.16
         public const byte VERSION_0017 = 4; // preclassic 0.0.17 / 0.0.18
         public const byte VERSION_0019 = 5; // preclassic 0.0.19
-        public const byte VERSION_0023 = 6; // preclassic 0.0.23a
+        public const byte VERSION_0020 = 6; // preclassic 0.0.20 / 0.0.21 / 0.0.23
         public const byte VERSION_0030 = 7; // classic
         
         public static string salt = "";


### PR DESCRIPTION
This should allow all multiplayer supporting versions of preclassic to connect now. (as version 3 was apparently first public protocol version)

Tested joining another map / modifying blocks / spawning/despawning entities, seemed to work well enough, but there's probably still some issues I didn't pick up though (e.g. I have no idea what changed between protocol version 3 and 4)