### PR TITLE
#636 Added support for multiple heartbeats.

### DIFF
--- a/MCGalaxy/Config/StringAttributes.cs
+++ b/MCGalaxy/Config/StringAttributes.cs
@@ -81,7 +81,20 @@ namespace MCGalaxy.Config {
         }
     }
     
-    public sealed class ConfigStringListAttribute : ConfigAttribute {
+    public sealed class ConfigStringListAttribute : ConfigAttribute
+    {
+        private readonly bool allowEmpty;
+        private readonly string allowedChars;
+        private readonly string[] defValue;
+
+        public ConfigStringListAttribute(string name, string section, string[] def, bool empty, string allowed)
+            : base(name, section) { defValue = def; allowEmpty = empty; allowedChars = allowed; }
+
+        public ConfigStringListAttribute(string name, string section, string[] def, bool empty)
+            : base(name, section) { defValue = def; allowEmpty = empty; }
+        
+        public ConfigStringListAttribute(string name, string section, string[] def) 
+            : base(name, section) { defValue = def; }
         
         public ConfigStringListAttribute(string name, string section) 
             : base(name, section) { }
@@ -92,7 +105,26 @@ namespace MCGalaxy.Config {
         
         public override string Serialise(object value) {
             List<string> elements = (List<string>)value;
-            return elements.Join(",");
+            List<string> sanitizedElements = new List<string>();
+            
+            foreach (string url in elements)
+            {
+                bool reject = false;
+                
+                foreach (char c in url) {
+                    if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) continue;                
+                    if (allowedChars.IndexOf(c) >= 0) continue;
+                    reject = true;
+                }
+                
+                if (!reject)
+                    sanitizedElements.Add(url);
+            }
+
+            if (sanitizedElements.Count < 1 && !allowEmpty)
+                sanitizedElements = new List<string>(defValue);
+            
+            return sanitizedElements.Join(",");
         }
     }
 }

--- a/MCGalaxy/MCGalaxy_.csproj
+++ b/MCGalaxy/MCGalaxy_.csproj
@@ -601,6 +601,7 @@
     <Compile Include="Network\BaseWebSocket.cs" />
     <Compile Include="Network\Heartbeat\ClassiCube.cs" />
     <Compile Include="Network\Heartbeat\Heartbeat.cs" />
+    <Compile Include="Network\Heartbeat\HeartbeatService.cs" />
     <Compile Include="Modules\Relay\IRC\IRCBot.cs" />
     <Compile Include="Network\Listeners.cs" />
     <Compile Include="Network\Packets\Opcode.cs" />

--- a/MCGalaxy/Network/Heartbeat/ClassiCube.cs
+++ b/MCGalaxy/Network/Heartbeat/ClassiCube.cs
@@ -28,8 +28,9 @@ namespace MCGalaxy.Network {
     /// <summary> Heartbeat to ClassiCube.net's web server. </summary>
     public sealed class ClassiCubeBeat : Heartbeat {
         string proxyUrl;
-        public override string URL { get { return Server.Config.HeartbeatURL; } }
         public string ServerHash;
+        
+        public ClassiCubeBeat(string URL) : base(URL) { }
         
         public override void Init() {
             string hostUrl = "";
@@ -117,7 +118,7 @@ namespace MCGalaxy.Network {
             return response.Substring(response.LastIndexOf('/') + 1);
         }
         
-        static string GetError(string json) {
+        string GetError(string json) {
             JsonReader reader = new JsonReader(json);
             // silly design, but form of json is:
             // {

--- a/MCGalaxy/Network/Heartbeat/Heartbeat.cs
+++ b/MCGalaxy/Network/Heartbeat/Heartbeat.cs
@@ -1,45 +1,24 @@
-/*
-    Copyright 2012 MCForge
-    
-    Dual-licensed under the Educational Community License, Version 2.0 and
-    the GNU General Public License, Version 3 (the "Licenses"); you may
-    not use this file except in compliance with the Licenses. You may
-    obtain a copy of the Licenses at
-    
-    http://www.opensource.org/licenses/ecl2.php
-    http://www.gnu.org/licenses/gpl-3.0.html
-    
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the Licenses are distributed on an "AS IS"
-    BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-    or implied. See the Licenses for the specific language governing
-    permissions and limitations under the Licenses.
- */
-using System;
-using System.Collections.Generic;
 using System.Net;
-using System.Net.Cache;
-using System.Text;
-using MCGalaxy.Tasks;
 
 namespace MCGalaxy.Network 
 {
     /// <summary> Repeatedly sends a heartbeat every certain interval to a web server. </summary>
-    public abstract class Heartbeat 
+    public abstract class Heartbeat
     {
+        public Heartbeat(string URL)
+        {
+            this.URL = URL;
+        }
+
         /// <summary> The max number of retries attempted for a heartbeat. </summary>
-        public const int MAX_RETRIES = 3;
-        
-        /// <summary> List of all heartbeats to pump. </summary>
-        public static List<Heartbeat> Heartbeats = new List<Heartbeat>() { new ClassiCubeBeat() };
-        
-        
+        public int maxRetries = 3;
+
         /// <summary> Gets the URL the heartbeat is sent to. </summary>
-        public abstract string URL { get; }
+        public string URL;
         
         /// <summary> Salt used for verifying player names </summary>
         public string Salt = "";
-        
+
         /// <summary> Initialises data for this heartbeat. </summary>
         public abstract void Init();
         
@@ -51,56 +30,5 @@ namespace MCGalaxy.Network
         
         /// <summary> Called when a response is received from the web server. </summary>
         public abstract void OnResponse(string response);
-
-        
-        /// <summary> Initialises all heartbeats. </summary>
-        public static void InitHeartbeats() {
-            foreach (Heartbeat beat in Heartbeats) {
-                beat.Init();
-                beat.Salt = Server.GenerateSalt();
-                Pump(beat);
-            }
-            
-            if (heartbeatTask != null) return;
-            heartbeatTask = Server.Background.QueueRepeat(OnBeat, null, 
-                                                          TimeSpan.FromSeconds(30));
-        }
-        
-        static SchedulerTask heartbeatTask;
-        static void OnBeat(SchedulerTask task) {
-            foreach (Heartbeat beat in Heartbeats) { Pump(beat); }
-        }
-        
-
-        /// <summary> Pumps the specified heartbeat. </summary>
-        public static void Pump(Heartbeat beat) {
-            byte[] data = Encoding.ASCII.GetBytes(beat.GetHeartbeatData());
-            Exception lastEx = null;
-
-            for (int i = 0; i < MAX_RETRIES; i++) {
-                try {
-                    HttpWebRequest req = HttpUtil.CreateRequest(beat.URL);
-                    req.Method = "POST";
-                    req.ContentType = "application/x-www-form-urlencoded";
-                    req.CachePolicy = new RequestCachePolicy(RequestCacheLevel.NoCacheNoStore);
-                    req.Timeout = 10000;
-                    
-                    beat.OnRequest(req);
-                    HttpUtil.SetRequestData(req, data);
-                    WebResponse res = req.GetResponse();
-                    
-                    string response = HttpUtil.GetResponseText(res);
-                    beat.OnResponse(response);
-                    return;
-                } catch (Exception ex) {
-                    HttpUtil.DisposeErrorResponse(ex);
-                    lastEx = ex;
-                    continue;
-                }
-            }
-            
-            string hostUrl = new Uri(beat.URL).Host;
-            Logger.Log(LogType.Warning, "Failed to send heartbeat to {0} ({1})", hostUrl, lastEx.Message);
-        }
     }
 }

--- a/MCGalaxy/Network/Heartbeat/HeartbeatService.cs
+++ b/MCGalaxy/Network/Heartbeat/HeartbeatService.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Net;
+using System.Net.Cache;
+using System.Text;
+using MCGalaxy.Tasks;
+
+namespace MCGalaxy.Network
+{
+    public class HeartbeatService
+    {
+        /// <summary> List of all heartbeats to pump. </summary>
+        private List<Heartbeat> heartbeats = new List<Heartbeat>() { };
+
+        public ReadOnlyCollection<Heartbeat> ReadHeartbeats()
+        {
+            return heartbeats.AsReadOnly();
+        }
+        
+        public void RegisterHeartbeat(Heartbeat heartbeat)
+        {
+            heartbeats.Add(heartbeat);
+            heartbeat.Init();
+            heartbeat.Salt = Server.GenerateSalt();
+        }
+
+        public void StartBeating()
+        {
+            if (heartbeatTask != null) return;
+            heartbeatTask = Server.Background.QueueRepeat(OnBeat, null, 
+                TimeSpan.FromSeconds(30));
+        }
+
+        SchedulerTask heartbeatTask;
+        void OnBeat(SchedulerTask task) {
+            foreach (Heartbeat beat in heartbeats) { Pump(beat); }
+        }
+        
+
+        /// <summary> Pumps the specified heartbeat. </summary>
+        public void Pump(Heartbeat beat) {
+            byte[] data = Encoding.ASCII.GetBytes(beat.GetHeartbeatData());
+            Exception lastEx = null;
+
+            for (int i = 0; i < beat.maxRetries; i++) {
+                try {
+                    HttpWebRequest req = HttpUtil.CreateRequest(beat.URL);
+                    req.Method = "POST";
+                    req.ContentType = "application/x-www-form-urlencoded";
+                    req.CachePolicy = new RequestCachePolicy(RequestCacheLevel.NoCacheNoStore);
+                    req.Timeout = 10000;
+                    
+                    beat.OnRequest(req);
+                    HttpUtil.SetRequestData(req, data);
+                    WebResponse res = req.GetResponse();
+                    
+                    string response = HttpUtil.GetResponseText(res);
+                    beat.OnResponse(response);
+                    return;
+                } catch (Exception ex) {
+                    HttpUtil.DisposeErrorResponse(ex);
+                    lastEx = ex;
+                }
+            }
+            
+            string hostUrl = new Uri(beat.URL).Host;
+            Logger.Log(LogType.Warning, "Failed to send heartbeat to {0} ({1})", hostUrl, lastEx.Message);
+        }
+    }
+}

--- a/MCGalaxy/Server/Authenticator.cs
+++ b/MCGalaxy/Server/Authenticator.cs
@@ -34,7 +34,7 @@ namespace MCGalaxy {
         public virtual bool VerifyLogin(Player p, string mppass) {
             if (!Server.Config.VerifyNames) return true;
             
-            foreach (Heartbeat hb in Heartbeat.Heartbeats)
+            foreach (Heartbeat hb in Server.heartbeatService.ReadHeartbeats())
             {
                 string calculated = Server.CalcMppass(p.truename, hb.Salt);
                 

--- a/MCGalaxy/Server/Server.Fields.cs
+++ b/MCGalaxy/Server/Server.Fields.cs
@@ -88,8 +88,10 @@ namespace MCGalaxy {
         public const byte VERSION_0019 = 5; // preclassic 0.0.19
         public const byte VERSION_0020 = 6; // preclassic 0.0.20 / 0.0.21 / 0.0.23
         public const byte VERSION_0030 = 7; // classic
-        
+
         public static bool chatmod, flipHead;
         public static bool shuttingDown;
+
+        public static HeartbeatService heartbeatService;
     }
 }

--- a/MCGalaxy/Server/Server.Init.cs
+++ b/MCGalaxy/Server/Server.Init.cs
@@ -108,8 +108,14 @@ namespace MCGalaxy {
         }
         
         static void InitHeartbeat(SchedulerTask task) {
-            try {
-                Heartbeat.InitHeartbeats();
+            try
+            {
+                heartbeatService = new HeartbeatService();
+                foreach (string heartbeatUrl in Config.HeartbeatURLs)
+                {
+                    heartbeatService.RegisterHeartbeat(new ClassiCubeBeat(heartbeatUrl));
+                }
+                heartbeatService.StartBeating();
             } catch (Exception ex) {
                 Logger.LogError("Error initialising heartbeat", ex);
             }

--- a/MCGalaxy/Server/ServerConfig.cs
+++ b/MCGalaxy/Server/ServerConfig.cs
@@ -61,8 +61,8 @@ namespace MCGalaxy {
         public string SslCertPath = "";
         [ConfigString("ssl-certificate-password", "Other", "", true)]
         public string SslCertPass = "";
-        [ConfigString("HeartbeatURL", "Other", "http://www.classicube.net/heartbeat.jsp", false, ":/.")]
-        public string HeartbeatURL = "http://www.classicube.net/heartbeat.jsp";
+        [ConfigStringList("HeartbeatURLs", "Other", new string[] { "http://www.classicube.net/heartbeat.jsp" }, false, ":/.")]
+        public List<string> HeartbeatURLs = new List<string>();
         
         [ConfigBool("core-secret-commands", "Other", true)]
         public bool CoreSecretCommands = true;


### PR DESCRIPTION
Per #636 I have added support for registering multiple heartbeat urls.

At the moment all are using the ClassiCube heartbeat. This could be extended to support various heartbeat protocols and implementations (eg, classicube://someurl.com, betacraft://betacraft.pl/heartbeat.jsp etc). Though personally I think that one implementation passing as much relevant data as suitable should be enough, and that we shouldn't have different consumer API specs (so the classicube spec should be fit for betacraft and if not, betacraft should adapt).

- Split out the heartbeat service and heartbeat datatype into separate classes.
- Changed the HeartbeatURL config option to HeartbeatURLs.