### PR TITLE
Improvements to spheroid draw ops

### DIFF
--- a/MCGalaxy/Commands/building/CmdDraw.cs
+++ b/MCGalaxy/Commands/building/CmdDraw.cs
@@ -41,6 +41,7 @@ namespace MCGalaxy.Commands.Building {
             if (msg == "sphere")    return DrawMode.sphere;
             if (msg == "hsphere")   return DrawMode.hsphere;
             if (msg == "volcano")   return DrawMode.volcano;
+            if (msg == "cylinder")  return DrawMode.hollow;
             return DrawMode.normal;
         }
         
@@ -58,6 +59,7 @@ namespace MCGalaxy.Commands.Building {
                 case DrawMode.sphere:  op = new AdvSphereDrawOp(); break;
                 case DrawMode.hsphere: op = new AdvHollowSphereDrawOp(); break;
                 case DrawMode.volcano: op = new AdvVolcanoDrawOp(); break;
+                case DrawMode.hollow:  op = new CylinderDrawOp(); break;
             }
             if (op == null) { Help(dArgs.Player); return null; }
 
@@ -97,7 +99,7 @@ namespace MCGalaxy.Commands.Building {
             };
 
             if (UsesHeight(dArgs)) {
-                m[1].Y += meta.height;
+                m[1].Y += meta.height - 1;
             } else {
                 m[0].Y -= radius; m[1].Y += radius;
             }
@@ -119,7 +121,7 @@ namespace MCGalaxy.Commands.Building {
             p.Message("&T/Draw [object] [baseradius] [height] <brush args>");
             p.Message("&T/Draw [object] [radius] <brush args>");
             p.Message("&HDraws an object at the specified point.");
-            p.Message("   &HObjects: &fcone/hcone/icone/hicone");
+            p.Message("   &HObjects: &fcone/hcone/icone/hicone/cylinder/");
             p.Message("     &fpyramid/hpyramid/ipyramid/hipyramid/volcano");
             p.Message("   &HObjects with only radius: &fsphere/hsphere");
             p.Message("   &HNote 'h' means hollow, 'i' means inverse");

--- a/MCGalaxy/Commands/building/CmdDraw.cs
+++ b/MCGalaxy/Commands/building/CmdDraw.cs
@@ -45,11 +45,11 @@ namespace MCGalaxy.Commands.Building {
         }
         
         protected override DrawOp GetDrawOp(DrawArgs dArgs) {
-            AdvDrawOp op = null;
+            DrawOp op = null;
             switch (dArgs.Mode) {
-                case DrawMode.cone:   op = new AdvConeDrawOp(); break;
+                case DrawMode.cone:   op = new ConeDrawOp(); break;
                 case DrawMode.hcone:  op = new AdvHollowConeDrawOp(); break;
-                case DrawMode.icone:  op = new AdvConeDrawOp(true); break;
+                case DrawMode.icone:  op = new ConeDrawOp(true); break;
                 case DrawMode.hicone: op = new AdvHollowConeDrawOp(true); break;
                 case DrawMode.pyramid:   op = new AdvPyramidDrawOp(); break;
                 case DrawMode.hpyramid:  op = new AdvHollowPyramidDrawOp(); break;
@@ -66,7 +66,7 @@ namespace MCGalaxy.Commands.Building {
             string[] args = dArgs.Message.SplitSpaces();
             Player p = dArgs.Player;
             
-            if (op.UsesHeight) {
+            if (UsesHeight(dArgs)) {
                 if (args.Length < 3) {
                     p.Message("You need to provide the radius and the height for the {0}.", args[0]);
                 } else {
@@ -87,7 +87,6 @@ namespace MCGalaxy.Commands.Building {
         }
         
         protected override void GetMarks(DrawArgs dArgs, ref Vec3S32[] m) {
-            AdvDrawOp op = (AdvDrawOp)dArgs.Op;
             AdvDrawMeta meta = (AdvDrawMeta)dArgs.Meta;
             int radius = meta.radius;
             
@@ -97,7 +96,7 @@ namespace MCGalaxy.Commands.Building {
                 new Vec3S32(P.X + radius, P.Y, P.Z + radius),
             };
 
-            if (op.UsesHeight) {
+            if (UsesHeight(dArgs)) {
                 m[1].Y += meta.height;
             } else {
                 m[0].Y -= radius; m[1].Y += radius;
@@ -105,11 +104,16 @@ namespace MCGalaxy.Commands.Building {
         }
         
         protected override void GetBrush(DrawArgs dArgs) {
-            int argsUsed = ((AdvDrawOp)dArgs.Op).UsesHeight ? 3 : 2;
+            int argsUsed = UsesHeight(dArgs) ? 3 : 2;
             dArgs.BrushArgs = dArgs.Message.Splice(argsUsed, 0);
         }
         
         class AdvDrawMeta { public int radius, height; }
+
+        static bool UsesHeight(DrawArgs args) {
+            DrawMode mode = args.Mode;
+            return !(mode == DrawMode.sphere || mode == DrawMode.hsphere);
+        }
         
         public override void Help(Player p) {
             p.Message("&T/Draw [object] [baseradius] [height] <brush args>");

--- a/MCGalaxy/Commands/building/CmdSpheroid.cs
+++ b/MCGalaxy/Commands/building/CmdSpheroid.cs
@@ -24,7 +24,7 @@ namespace MCGalaxy.Commands.Building {
         public override string name { get { return "Spheroid"; } }
         public override string shortcut { get { return "e"; } }
         public override CommandAlias[] Aliases {
-            get { return new[] { new CommandAlias("eh", "hollow"), new CommandAlias("cylinder", "vertical") }; }
+            get { return new[] { new CommandAlias("eh", "hollow"), new CommandAlias("Cylinder", "cylinder"), new CommandAlias("Cone", "cone") }; }
         }
         
         protected override void GetBrush(DrawArgs dArgs) {
@@ -37,6 +37,8 @@ namespace MCGalaxy.Commands.Building {
             if (msg == "solid")    return DrawMode.solid;
             if (msg == "hollow")   return DrawMode.hollow;
             if (msg == "vertical") return DrawMode.vertical;
+            if (msg == "cylinder") return DrawMode.vertical;
+            if (msg == "cone")     return DrawMode.cone;
             return DrawMode.normal;
         }
         
@@ -44,6 +46,7 @@ namespace MCGalaxy.Commands.Building {
             switch (dArgs.Mode) {
                 case DrawMode.hollow:   return new EllipsoidHollowDrawOp();
                 case DrawMode.vertical: return new CylinderDrawOp();
+                case DrawMode.cone:     return new ConeDrawOp();
             }
             return new EllipsoidDrawOp();
         }
@@ -52,7 +55,7 @@ namespace MCGalaxy.Commands.Building {
             p.Message("&T/Spheroid <brush args>");
             p.Message("&HDraws a spheroid between two points.");
             p.Message("&T/Spheroid [mode] <brush args>");
-            p.Message("&HModes: &fsolid/hollow/vertical(a vertical tube)");    
+            p.Message("&HModes: &fsolid/hollow/cylinder/cone");    
             p.Message(BrushHelpLine);
         }
     }

--- a/MCGalaxy/Commands/building/CmdSpheroid.cs
+++ b/MCGalaxy/Commands/building/CmdSpheroid.cs
@@ -24,7 +24,7 @@ namespace MCGalaxy.Commands.Building {
         public override string name { get { return "Spheroid"; } }
         public override string shortcut { get { return "e"; } }
         public override CommandAlias[] Aliases {
-            get { return new[] { new CommandAlias("eh", "hollow"), new CommandAlias("Cylinder", "cylinder"), new CommandAlias("Cone", "cone") }; }
+            get { return new[] { new CommandAlias("eh", "hollow"), new CommandAlias("Cone", "cone"), new CommandAlias("Cylinder", "cylinder") }; }
         }
         
         protected override void GetBrush(DrawArgs dArgs) {

--- a/MCGalaxy/Drawing/DrawOps/AdvConeDrawOps.cs
+++ b/MCGalaxy/Drawing/DrawOps/AdvConeDrawOps.cs
@@ -70,7 +70,7 @@ namespace MCGalaxy.Drawing.Ops
         public override string Name { get { return "Adv Volcano"; } }
         
         public override long BlocksAffected(Level lvl, Vec3S32[] marks) {
-            long R = Radius, H = Max.Y - Min.Y;
+            long R = Radius, H = Height;
             return (long)(Math.PI / 3 * (R * R * H));
         }
         

--- a/MCGalaxy/Drawing/DrawOps/AdvConeDrawOps.cs
+++ b/MCGalaxy/Drawing/DrawOps/AdvConeDrawOps.cs
@@ -27,43 +27,6 @@ using BlockID = System.UInt16;
 
 namespace MCGalaxy.Drawing.Ops 
 {
-    public class AdvConeDrawOp : AdvDrawOp 
-    {
-        public override string Name { get { return "Adv Cone"; } }
-        public AdvConeDrawOp(bool invert = false) { Invert = invert; }
-        
-        public override long BlocksAffected(Level lvl, Vec3S32[] marks) {
-            long R = Radius, H = Max.Y - Min.Y;
-            return (long)(Math.PI / 3 * (R * R * H));
-        }
-        
-        public override void Perform(Vec3S32[] marks, Brush brush, DrawOpOutput output) {
-            Vec3U16 p1 = Clamp(Min), p2 = Clamp(Max);
-            // Based on SpheroidDrawOp
-            double cx  = (Min.X + Max.X) / 2.0, cz = (Min.Z + Max.Z) / 2.0;
-            int height = Max.Y - Min.Y;
-
-            for (ushort y = p1.Y; y <= p2.Y; y++)
-            {
-                int curHeight = Invert ? y - Min.Y : Max.Y - y;
-                if (curHeight == 0) continue;
-                double curRadius = (double)Radius * curHeight / height;
-
-                double r  = curRadius + 0.25;
-                double r2 = 1 / (r * r);
-
-                for (ushort z = p1.Z; z <= p2.Z; z++)
-                    for (ushort x = p1.X; x <= p2.X; x++)
-                {
-                    double dx = x - cx, dz = z - cz;
-
-                    if (dx * dx * r2 + dz * dz * r2 <= 1)
-                        output(Place(x, y, z, brush));
-                 }
-            }
-        }
-    }
-    
     public class AdvHollowConeDrawOp : AdvDrawOp 
     {
         public override string Name { get { return "Adv Hollow Cone"; } }

--- a/MCGalaxy/Drawing/DrawOps/AdvConeDrawOps.cs
+++ b/MCGalaxy/Drawing/DrawOps/AdvConeDrawOps.cs
@@ -33,7 +33,7 @@ namespace MCGalaxy.Drawing.Ops
         public AdvHollowConeDrawOp(bool invert = false) { Invert = invert; }
         
         public override long BlocksAffected(Level lvl, Vec3S32[] marks) {
-            long R = Radius, H = Max.Y - Min.Y;
+            long R = Radius, H = Height;
             double outer = (int)(Math.PI / 3 * (R * R * H));
             double inner = (int)(Math.PI / 3 * ((R - 1) * (R - 1) * (H - 1)));
             return (long)(outer - inner);
@@ -42,16 +42,13 @@ namespace MCGalaxy.Drawing.Ops
         public override void Perform(Vec3S32[] marks, Brush brush, DrawOpOutput output) {
             Vec3U16 p1 = Clamp(Min), p2 = Clamp(Max);
             Vec3S32 C  = (Min + Max) / 2;
-            int height = Max.Y - Min.Y;
+            int height = Height;
 
             for (ushort y = p1.Y; y <= p2.Y; y++)
             {
-                int dy = y - Min.Y;
-                int curHeight = Invert ? dy : height - dy;
-                if (curHeight == 0) continue;
-                
-                int curRadius  = Radius * curHeight       / height;
-                int curRadius2 = Radius * (curHeight - 1) / height;
+                int dy         = Invert ? y - Min.Y : Max.Y - y;
+                int curRadius  = Radius * (dy + 1) / height;
+                int curRadius2 = Radius * (dy    ) / height;
                 
                 for (ushort z = p1.Z; z <= p2.Z; z++)
                     for (ushort x = p1.X; x <= p2.X; x++)
@@ -80,16 +77,13 @@ namespace MCGalaxy.Drawing.Ops
         public override void Perform(Vec3S32[] marks, Brush brush, DrawOpOutput output) {
             Vec3U16 p1 = Clamp(Min), p2 = Clamp(Max);
             Vec3S32 C  = (Min + Max) / 2;
-            int height = Max.Y - Min.Y;
+            int height = Height;
 
             for (ushort y = p1.Y; y <= p2.Y; y++)
             {
-                int yy = y - Min.Y;
-                int curHeight = height - yy;
-                if (curHeight == 0) continue;
-                
-                int curRadius  = Radius * curHeight       / height;
-                int curRadius2 = Radius * (curHeight - 1) / height;
+                int dy         = Max.Y - y;
+                int curRadius  = Radius * (dy + 1) / height;
+                int curRadius2 = Radius * (dy    ) / height;
                 
                 for (ushort z = p1.Z; z <= p2.Z; z++)
                     for (ushort x = p1.X; x <= p2.X; x++)

--- a/MCGalaxy/Drawing/DrawOps/AdvDrawOps.cs
+++ b/MCGalaxy/Drawing/DrawOps/AdvDrawOps.cs
@@ -29,6 +29,7 @@ namespace MCGalaxy.Drawing.Ops
     public abstract class AdvDrawOp : DrawOp 
     {
         public int Radius { get { return (Max.X - Min.X) / 2; } }
+        public int Height { get { return (Max.Y - Min.Y) + 1; } }
         
         public bool Invert;
     }

--- a/MCGalaxy/Drawing/DrawOps/AdvDrawOps.cs
+++ b/MCGalaxy/Drawing/DrawOps/AdvDrawOps.cs
@@ -39,8 +39,8 @@ namespace MCGalaxy.Drawing.Ops
         public override string Name { get { return "Adv Sphere"; } }
         
         public override long BlocksAffected(Level lvl, Vec3S32[] marks) {
-            long R = Radius;
-            return (long)(Math.PI * 4.0 / 3.0 * (R * R * R));
+            double R = Radius;
+            return (long)ShapedDrawOp.EllipsoidVolume(R, R, R);
         }
         
         public override void Perform(Vec3S32[] marks, Brush brush, DrawOpOutput output) {
@@ -64,9 +64,9 @@ namespace MCGalaxy.Drawing.Ops
         public override string Name { get { return "Adv Hollow Sphere"; } }
         
         public override long BlocksAffected(Level lvl, Vec3S32[] marks) {
-            long R = Radius;
-            double outer = (int)(Math.PI * 4.0 / 3.0 * (R * R * R));
-            double inner = (int)(Math.PI * 4.0 / 3.0 * ((R - 1) * (R - 1) * (R - 1)));
+            double R = Radius;
+            double outer = ShapedDrawOp.EllipsoidVolume(R,     R,     R    );
+            double inner = ShapedDrawOp.EllipsoidVolume(R - 1, R - 1, R - 1);
             return (long)(outer - inner);
         }
         

--- a/MCGalaxy/Drawing/DrawOps/AdvDrawOps.cs
+++ b/MCGalaxy/Drawing/DrawOps/AdvDrawOps.cs
@@ -31,12 +31,10 @@ namespace MCGalaxy.Drawing.Ops
         public int Radius { get { return (Max.X - Min.X) / 2; } }
         
         public bool Invert;
-        public virtual bool UsesHeight { get { return true; } }
     }
     
     public class AdvSphereDrawOp : AdvDrawOp 
     {
-        public override bool UsesHeight { get { return false; } }
         public override string Name { get { return "Adv Sphere"; } }
         
         public override long BlocksAffected(Level lvl, Vec3S32[] marks) {
@@ -62,7 +60,6 @@ namespace MCGalaxy.Drawing.Ops
     
     public class AdvHollowSphereDrawOp : AdvDrawOp 
     {
-        public override bool UsesHeight { get { return false; } }
         public override string Name { get { return "Adv Hollow Sphere"; } }
         
         public override long BlocksAffected(Level lvl, Vec3S32[] marks) {

--- a/MCGalaxy/Drawing/DrawOps/AdvPyramidDrawOps.cs
+++ b/MCGalaxy/Drawing/DrawOps/AdvPyramidDrawOps.cs
@@ -32,21 +32,19 @@ namespace MCGalaxy.Drawing.Ops
         public AdvPyramidDrawOp(bool invert = false) { Invert = invert; }
         
         public override long BlocksAffected(Level lvl, Vec3S32[] marks) {
-            long R = Radius, H = Max.Y - Min.Y;
+            long R = Radius, H = Height;
             return (R * R * H) / 3;
         }
         
         public override void Perform(Vec3S32[] marks, Brush brush, DrawOpOutput output) {
             Vec3U16 p1 = Clamp(Min), p2 = Clamp(Max);
             Vec3S32 C  = (Min + Max) / 2;
-            int height = Max.Y - Min.Y;
+            int height = Height;
 
             for (ushort y = p1.Y; y <= p2.Y; y++)
             {
-                int dy = y - Min.Y;
-                int curHeight = Invert ? dy : height - dy;
-                if (curHeight == 0) continue;
-                int curRadius = Radius * curHeight / height;
+                int dy = Invert ? y - Min.Y : Max.Y - y;
+                int curRadius = Radius * (dy + 1) / height;
                 
                 for (ushort z = p1.Z; z <= p2.Z; z++)
                     for (ushort x = p1.X; x <= p2.X; x++)
@@ -65,7 +63,7 @@ namespace MCGalaxy.Drawing.Ops
         public AdvHollowPyramidDrawOp(bool invert = false) { Invert = invert; }
         
         public override long BlocksAffected(Level lvl, Vec3S32[] marks) {
-            long R = Radius, H = Max.Y - Min.Y;
+            long R = Radius, H = Height;
             long outer = (R * R * H) / 3;
             long inner = ((R - 1) * (R - 1) * (H - 1)) / 3;
             return outer - inner;
@@ -74,16 +72,13 @@ namespace MCGalaxy.Drawing.Ops
         public override void Perform(Vec3S32[] marks, Brush brush, DrawOpOutput output) {
             Vec3U16 p1 = Clamp(Min), p2 = Clamp(Max);
             Vec3S32 C  = (Min + Max) / 2;
-            int height = Max.Y - Min.Y;
+            int height = Height;
 
             for (ushort y = p1.Y; y <= p2.Y; y++)
             {
-                int dy = y - Min.Y;
-                int curHeight = Invert ? dy : height - dy;
-                if (curHeight == 0) continue;
-                
-                int curRadius  = Radius * curHeight       / height;
-                int curRadius2 = Radius * (curHeight - 1) / height;
+                int dy         = Invert ? y - Min.Y : Max.Y - y;
+                int curRadius  = Radius * (dy + 1) / height;
+                int curRadius2 = Radius * (dy    ) / height;
                 
                 for (ushort z = p1.Z; z <= p2.Z; z++)
                     for (ushort x = p1.X; x <= p2.X; x++)

--- a/MCGalaxy/Drawing/DrawOps/SpheroidDrawOp.cs
+++ b/MCGalaxy/Drawing/DrawOps/SpheroidDrawOp.cs
@@ -21,19 +21,30 @@ using MCGalaxy.Maths;
 
 namespace MCGalaxy.Drawing.Ops 
 {
-    public class EllipsoidDrawOp : DrawOp 
+    public abstract class ShapedDrawOp : DrawOp
+    {
+        public double XRadius { get { return (Max.X - Min.X) / 2.0 + 0.25; } }
+        public double YRadius { get { return (Max.Y - Min.Y) / 2.0 + 0.25; } }
+        public double ZRadius { get { return (Max.Z - Min.Z) / 2.0 + 0.25; } }
+
+        public double XCentre { get { return (Min.X + Max.X) / 2.0; } }
+        public double YCentre { get { return (Min.Y + Max.Y) / 2.0; } }
+        public double ZCentre { get { return (Min.Z + Max.Z) / 2.0; } }
+    }
+
+    public class EllipsoidDrawOp : ShapedDrawOp
     {
         public override string Name { get { return "Ellipsoid"; } }
         
         public override long BlocksAffected(Level lvl, Vec3S32[] marks) {
-            double rx = (Max.X - Min.X) / 2.0 + 0.25, ry = (Max.Y - Min.Y) / 2.0 + 0.25, rz = (Max.Z - Min.Z) / 2.0 + 0.25;
+            double rx = XRadius, ry = YRadius, rz = ZRadius;
             return (int)(Math.PI * 4.0/3.0 * rx * ry * rz);
         }
         
         public override void Perform(Vec3S32[] marks, Brush brush, DrawOpOutput output) {
             /* Courtesy of fCraft's awesome Open-Source'ness :D */
-            double cx = (Min.X + Max.X) / 2.0, cy = (Min.Y + Max.Y) / 2.0, cz = (Min.Z + Max.Z) / 2.0;
-            double rx = (Max.X - Min.X) / 2.0 + 0.25, ry = (Max.Y - Min.Y) / 2.0 + 0.25, rz = (Max.Z - Min.Z) / 2.0 + 0.25;
+            double cx = XCentre, cy = YCentre, cz = ZCentre;
+            double rx = XRadius, ry = YRadius, rz = ZRadius;
             double rx2 = 1 / (rx * rx), ry2 = 1 / (ry * ry), rz2 = 1 / (rz * rz);
             Vec3U16 min = Clamp(Min), max = Clamp(Max);
             
@@ -48,19 +59,19 @@ namespace MCGalaxy.Drawing.Ops
         }
     }
     
-    public class EllipsoidHollowDrawOp : DrawOp 
+    public class EllipsoidHollowDrawOp : ShapedDrawOp
     {       
         public override string Name { get { return "Ellipsoid Hollow"; } }
         
         public override long BlocksAffected(Level lvl, Vec3S32[] marks) {
-            double rx = (Max.X - Min.X) / 2.0 + 0.25, ry = (Max.Y - Min.Y) / 2.0 + 0.25, rz = (Max.Z - Min.Z) / 2.0 + 0.25;
+            double rx = XRadius, ry = YRadius, rz = ZRadius;
             return (int)(Math.PI * 4.0/3.0 * rx * ry * rz);
         }
         
         public override void Perform(Vec3S32[] marks, Brush brush, DrawOpOutput output) {
             /* Courtesy of fCraft's awesome Open-Source'ness :D */
-            double cx = (Min.X + Max.X) / 2.0, cy = (Min.Y + Max.Y) / 2.0, cz = (Min.Z + Max.Z) / 2.0;
-            double rx = (Max.X - Min.X) / 2.0 + 0.25, ry = (Max.Y - Min.Y) / 2.0 + 0.25, rz = (Max.Z - Min.Z) / 2.0 + 0.25;
+            double cx = XCentre, cy = YCentre, cz = ZCentre;
+            double rx = XRadius, ry = YRadius, rz = ZRadius;
             double rx2 = 1 / (rx * rx), ry2 = 1 / (ry * ry), rz2 = 1 / (rz * rz);
             
             double smallrx2 = 1 / ((rx - 1) * (rx - 1));
@@ -81,20 +92,20 @@ namespace MCGalaxy.Drawing.Ops
         }
     }
     
-    public class CylinderDrawOp : DrawOp 
+    public class CylinderDrawOp : ShapedDrawOp
     {
         public override string Name { get { return "Cylinder"; } }
         
         public override long BlocksAffected(Level lvl, Vec3S32[] marks) {
-            double rx = (Max.X - Min.X) / 2.0 + 0.25, rz = (Max.Z - Min.Z) / 2.0 + 0.25;
+            double rx = XRadius, rz = ZRadius;
             int height = (Max.Y - Min.Y + 1);
             return (int)(Math.PI * rx * rz * height);
         }
         
         public override void Perform(Vec3S32[] marks, Brush brush, DrawOpOutput output) {            
             /* Courtesy of fCraft's awesome Open-Source'ness :D */
-            double cx = (Min.X + Max.X) / 2.0, cz = (Min.Z + Max.Z) / 2.0;
-            double rx = (Max.X - Min.X) / 2.0 + 0.25, rz = (Max.Z - Min.Z) / 2.0 + 0.25;
+            double cx = XCentre, cz = ZCentre;
+            double rx = XRadius, rz = ZRadius;
             double rx2 = 1 / (rx * rx), rz2 = 1 / (rz * rz);
             double smallrx2 = 1 / ((rx - 1) * (rx - 1));
             double smallrz2 = 1 / ((rz - 1) * (rz - 1));

--- a/MCGalaxy/Drawing/DrawOps/SpheroidDrawOps.cs
+++ b/MCGalaxy/Drawing/DrawOps/SpheroidDrawOps.cs
@@ -50,13 +50,13 @@ namespace MCGalaxy.Drawing.Ops
             double rx2 = 1 / (rx * rx), ry2 = 1 / (ry * ry), rz2 = 1 / (rz * rz);
             Vec3U16 min = Clamp(Min), max = Clamp(Max);
             
-            for (ushort yy = min.Y; yy <= max.Y; yy++)
-                for (ushort zz = min.Z; zz <= max.Z; zz++)
-                    for (ushort xx = min.X; xx <= max.X; xx++)
+            for (ushort y = min.Y; y <= max.Y; y++)
+                for (ushort z = min.Z; z <= max.Z; z++)
+                    for (ushort x = min.X; x <= max.X; x++)
             {
-                double dx = xx - cx, dy = yy - cy, dz = zz - cz;
+                double dx = x - cx, dy = y - cy, dz = z - cz;
                 if ((dx * dx) * rx2 + (dy * dy) * ry2 + (dz * dz) * rz2 <= 1)
-                    output(Place(xx, yy, zz, brush));
+                    output(Place(x, y, z, brush));
             }
         }
     }
@@ -74,22 +74,25 @@ namespace MCGalaxy.Drawing.Ops
             /* Courtesy of fCraft's awesome Open-Source'ness :D */
             double cx = XCentre, cy = YCentre, cz = ZCentre;
             double rx = XRadius, ry = YRadius, rz = ZRadius;
-            double rx2 = 1 / (rx * rx), ry2 = 1 / (ry * ry), rz2 = 1 / (rz * rz);
-            
-            double smallrx2 = 1 / ((rx - 1) * (rx - 1));
-            double smallry2 = 1 / ((ry - 1) * (ry - 1));
-            double smallrz2 = 1 / ((rz - 1) * (rz - 1));
+            double outer_rx2 = 1 / (rx * rx);
+            double outer_ry2 = 1 / (ry * ry);
+            double outer_rz2 = 1 / (rz * rz);
+            double inner_rx2 = 1 / ((rx - 1) * (rx - 1));
+            double inner_ry2 = 1 / ((ry - 1) * (ry - 1));
+            double inner_rz2 = 1 / ((rz - 1) * (rz - 1));
             Vec3U16 min = Clamp(Min), max = Clamp(Max);
             
-            for (ushort yy = min.Y; yy <= max.Y; yy++)
-                for (ushort zz = min.Z; zz <= max.Z; zz++)
-                    for (ushort xx = min.X; xx <= max.X; xx++)
+            for (ushort y = min.Y; y <= max.Y; y++)
+                for (ushort z = min.Z; z <= max.Z; z++)
+                    for (ushort x = min.X; x <= max.X; x++)
             {
-                double dx = xx - cx, dy = yy - cy, dz = zz - cz;
+                double dx = x - cx, dy = y - cy, dz = z - cz;
                 dx *= dx; dy *= dy; dz *= dz;
-                bool inRange = dx * rx2 + dy * ry2 + dz * rz2 <= 1;
-                if (inRange && (dx * smallrx2 + dy * smallry2 + dz * smallrz2 > 1))
-                    output(Place(xx, yy, zz, brush));
+
+                if (dx * outer_rx2 + dy * outer_ry2 + dz * outer_rz2 > 1)
+                    continue; // outside ellipsoid radius
+                if (dx * inner_rx2 + dy * inner_ry2 + dz * inner_rz2 > 1)
+                    output(Place(x, y, z, brush));
             }
         }
     }
@@ -106,20 +109,23 @@ namespace MCGalaxy.Drawing.Ops
             /* Courtesy of fCraft's awesome Open-Source'ness :D */
             double cx = XCentre, cz = ZCentre;
             double rx = XRadius, rz = ZRadius;
-            double rx2 = 1 / (rx * rx), rz2 = 1 / (rz * rz);
-            double smallrx2 = 1 / ((rx - 1) * (rx - 1));
-            double smallrz2 = 1 / ((rz - 1) * (rz - 1));
+            double outer_rx2 = 1 / (rx * rx);
+            double outer_rz2 = 1 / (rz * rz);
+            double inner_rx2 = 1 / ((rx - 1) * (rx - 1));
+            double inner_rz2 = 1 / ((rz - 1) * (rz - 1));
             Vec3U16 p1 = Clamp(Min), p2 = Clamp(Max);
             
-            for (ushort yy = p1.Y; yy <= p2.Y; yy++)
-                for (ushort zz = p1.Z; zz <= p2.Z; zz++)
-                    for (ushort xx = p1.X; xx <= p2.X; xx++)
+            for (ushort y = p1.Y; y <= p2.Y; y++)
+                for (ushort z = p1.Z; z <= p2.Z; z++)
+                    for (ushort x = p1.X; x <= p2.X; x++)
             {
-                double dx = xx - cx, dz = zz - cz;
+                double dx = x - cx, dz = z - cz;
                 dx *= dx; dz *= dz;
-                bool inRange = dx * rx2 + dz * rz2 <= 1;
-                if (inRange && (dx * smallrx2 + dz * smallrz2 > 1))
-                    output(Place(xx, yy, zz, brush));
+
+                if (dx * outer_rx2 + dz * outer_rz2 > 1)
+                    continue; // outside cylinder radius
+                if (dx * inner_rx2 + dz * inner_rz2 > 1)
+                    output(Place(x, y, z, brush));
             }
         }
     }

--- a/MCGalaxy/Drawing/DrawOps/SpheroidDrawOps.cs
+++ b/MCGalaxy/Drawing/DrawOps/SpheroidDrawOps.cs
@@ -30,6 +30,8 @@ namespace MCGalaxy.Drawing.Ops
         public double XCentre { get { return (Min.X + Max.X) / 2.0; } }
         public double YCentre { get { return (Min.Y + Max.Y) / 2.0; } }
         public double ZCentre { get { return (Min.Z + Max.Z) / 2.0; } }
+
+        public int Height { get { return (Max.Y - Min.Y) + 1; } }
     }
 
     public class EllipsoidDrawOp : ShapedDrawOp
@@ -97,8 +99,7 @@ namespace MCGalaxy.Drawing.Ops
         public override string Name { get { return "Cylinder"; } }
         
         public override long BlocksAffected(Level lvl, Vec3S32[] marks) {
-            int height = (Max.Y - Min.Y + 1);
-            return (int)(Math.PI * XRadius * ZRadius * height);
+            return (int)(Math.PI * XRadius * ZRadius * Height);
         }
         
         public override void Perform(Vec3S32[] marks, Brush brush, DrawOpOutput output) {            
@@ -130,21 +131,18 @@ namespace MCGalaxy.Drawing.Ops
         public ConeDrawOp(bool invert = false) { Invert = invert; }
         
         public override long BlocksAffected(Level lvl, Vec3S32[] marks) {
-            long H = Max.Y - Min.Y;
-            return (long)(Math.PI / 3 * (XRadius * ZRadius * H));
+            return (long)(Math.PI / 3 * (XRadius * ZRadius * Height));
         }
         
         public override void Perform(Vec3S32[] marks, Brush brush, DrawOpOutput output) {
             Vec3U16 p1 = Clamp(Min), p2 = Clamp(Max);
-            // Based on SpheroidDrawOp
             double cx  = XCentre, cz = ZCentre;
-            int height = Max.Y - Min.Y;
+            int height = Height;
 
             for (ushort y = p1.Y; y <= p2.Y; y++)
             {
-                int curHeight = Invert ? y - Min.Y : Max.Y - y;
-                if (curHeight == 0) continue;
-                double T = (double)curHeight / height;
+                int dy   = Invert ? y - Min.Y : Max.Y - y;
+                double T = (double)(dy + 1) / height;
 
                 double rx  = ((Max.X - Min.X) / 2.0) * T + 0.25;
                 double rz  = ((Max.Z - Min.Z) / 2.0) * T + 0.25;

--- a/MCGalaxy/Drawing/DrawOps/SpheroidDrawOps.cs
+++ b/MCGalaxy/Drawing/DrawOps/SpheroidDrawOps.cs
@@ -32,6 +32,19 @@ namespace MCGalaxy.Drawing.Ops
         public double ZCentre { get { return (Min.Z + Max.Z) / 2.0; } }
 
         public int Height { get { return (Max.Y - Min.Y) + 1; } }
+
+
+        public static double EllipsoidVolume(double rx, double ry, double rz) {
+            return Math.PI * 4.0 / 3.0 * (rx * ry * rz);
+        }
+
+        public static double ConeVolume(double rx, double rz, double height) {
+            return Math.PI / 3.0 * (rx * rz * height);
+        }
+
+        public static double CylinderVolume(double rx, double rz, double height) {
+            return Math.PI * (rx * rz * height);
+        }
     }
 
     public class EllipsoidDrawOp : ShapedDrawOp
@@ -39,8 +52,7 @@ namespace MCGalaxy.Drawing.Ops
         public override string Name { get { return "Ellipsoid"; } }
         
         public override long BlocksAffected(Level lvl, Vec3S32[] marks) {
-            double rx = XRadius, ry = YRadius, rz = ZRadius;
-            return (int)(Math.PI * 4.0/3.0 * rx * ry * rz);
+            return (long)EllipsoidVolume(XRadius, YRadius, ZRadius);
         }
         
         public override void Perform(Vec3S32[] marks, Brush brush, DrawOpOutput output) {
@@ -67,7 +79,9 @@ namespace MCGalaxy.Drawing.Ops
         
         public override long BlocksAffected(Level lvl, Vec3S32[] marks) {
             double rx = XRadius, ry = YRadius, rz = ZRadius;
-            return (int)(Math.PI * 4.0/3.0 * rx * ry * rz);
+            double outer = EllipsoidVolume(rx,     ry,     rz    );
+            double inner = EllipsoidVolume(rx - 1, ry - 1, rz - 1);
+            return (long)(outer - inner);
         }
         
         public override void Perform(Vec3S32[] marks, Brush brush, DrawOpOutput output) {
@@ -102,7 +116,10 @@ namespace MCGalaxy.Drawing.Ops
         public override string Name { get { return "Cylinder"; } }
         
         public override long BlocksAffected(Level lvl, Vec3S32[] marks) {
-            return (int)(Math.PI * XRadius * ZRadius * Height);
+            double rx = XRadius, rz = ZRadius, h = Height;
+            double outer = CylinderVolume(rx,     rz,     h);
+            double inner = CylinderVolume(rx - 1, rz - 1, h);
+            return (long)(outer - inner);
         }
         
         public override void Perform(Vec3S32[] marks, Brush brush, DrawOpOutput output) {            
@@ -137,7 +154,7 @@ namespace MCGalaxy.Drawing.Ops
         public ConeDrawOp(bool invert = false) { Invert = invert; }
         
         public override long BlocksAffected(Level lvl, Vec3S32[] marks) {
-            return (long)(Math.PI / 3 * (XRadius * ZRadius * Height));
+            return (long)ConeVolume(XRadius, ZRadius, Height);
         }
         
         public override void Perform(Vec3S32[] marks, Brush brush, DrawOpOutput output) {

--- a/MCGalaxy/Drawing/DrawOps/TorusDrawOp.cs
+++ b/MCGalaxy/Drawing/DrawOps/TorusDrawOp.cs
@@ -21,19 +21,19 @@ using MCGalaxy.Maths;
 
 namespace MCGalaxy.Drawing.Ops 
 {
-    public class TorusDrawOp : DrawOp 
+    public class TorusDrawOp : ShapedDrawOp 
     {
         public override string Name { get { return "Torus"; } }
         
         public override long BlocksAffected(Level lvl, Vec3S32[] marks) {
-            double rx = (Max.X - Min.X) / 2.0 + 0.25, ry = (Max.Y - Min.Y) / 2.0 + 0.25, rz = (Max.Z - Min.Z) / 2.0 + 0.25;
+            double rx = XRadius, ry = YRadius, rz = ZRadius;
             double rTube = ry, rCentre = Math.Min(rx, rz) - rTube;
             return (int)(2 * Math.PI * Math.PI * rTube * rTube * Math.Abs(rCentre));
         }
         
         public override void Perform(Vec3S32[] marks, Brush brush, DrawOpOutput output) {          
-            double cx = (Min.X + Max.X) / 2.0, cy = (Min.Y + Max.Y) / 2.0, cz = (Min.Z + Max.Z) / 2.0;
-            double rx = (Max.X - Min.X) / 2.0 + 0.25, ry = (Max.Y - Min.Y) / 2.0 + 0.25, rz = (Max.Z - Min.Z) / 2.0 + 0.25;
+            double cx = XCentre, cy = YCentre, cz = ZCentre;
+            double rx = XRadius, ry = YRadius, rz = ZRadius;
             double rTube = ry, rCentre = Math.Min(rx, rz) - rTube;
             Vec3U16 p1 = Clamp(Min), p2 = Clamp(Max);
             

--- a/MCGalaxy/MCGalaxy_.csproj
+++ b/MCGalaxy/MCGalaxy_.csproj
@@ -434,7 +434,7 @@
     <Compile Include="Drawing\DrawOps\RedoDrawOp.cs" />
     <Compile Include="Drawing\DrawOps\ReplaceDrawOp.cs" />
     <Compile Include="Drawing\DrawOps\RestoreSelectionDrawOp.cs" />
-    <Compile Include="Drawing\DrawOps\SpheroidDrawOp.cs" />
+    <Compile Include="Drawing\DrawOps\SpheroidDrawOps.cs" />
     <Compile Include="Drawing\DrawOps\PyramidDrawOp.cs" />
     <Compile Include="Drawing\DrawOps\SPlaceDrawOp.cs" />
     <Compile Include="Drawing\DrawOps\TorusDrawOp.cs" />


### PR DESCRIPTION
* Cones can now be drawn at any size using /cone (like /cylinder)
* /draw now supports drawing cylinders
* Fixed some spheroid draw ops having incorrect 'blocks affected' estimation