### PR TITLE
Rewrite SQL to avoid directly depending on System.Data

### DIFF
--- a/MCGalaxy/Blocks/Behaviour/WalkthroughBehaviour.cs
+++ b/MCGalaxy/Blocks/Behaviour/WalkthroughBehaviour.cs
@@ -17,7 +17,6 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Data;
 using MCGalaxy.Blocks.Extended;
 using MCGalaxy.Blocks.Physics;
 using MCGalaxy.Network;

--- a/MCGalaxy/Blocks/Extended/MessageBlock.cs
+++ b/MCGalaxy/Blocks/Extended/MessageBlock.cs
@@ -17,7 +17,6 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Data;
 using MCGalaxy.Maths;
 using MCGalaxy.SQL;
 

--- a/MCGalaxy/Blocks/Extended/Portal.cs
+++ b/MCGalaxy/Blocks/Extended/Portal.cs
@@ -17,7 +17,6 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Data;
 using MCGalaxy.Maths;
 using MCGalaxy.SQL;
 
@@ -55,7 +54,7 @@ namespace MCGalaxy.Blocks.Extended {
         }
         
         
-        internal static Vec3U16 ParseCoords(IDataRecord record) {
+        internal static Vec3U16 ParseCoords(ISqlRecord record) {
             Vec3U16 pos;
             pos.X = (ushort)record.GetInt32(0);
             pos.Y = (ushort)record.GetInt32(1);
@@ -63,7 +62,7 @@ namespace MCGalaxy.Blocks.Extended {
             return pos;
         }
         
-        static PortalExit ParseExit(IDataRecord record) {
+        static PortalExit ParseExit(ISqlRecord record) {
             PortalExit data = new PortalExit();
             data.Map = record.GetText(0);
             

--- a/MCGalaxy/Commands/Chat/CmdInbox.cs
+++ b/MCGalaxy/Commands/Chat/CmdInbox.cs
@@ -17,7 +17,6 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Data;
 using MCGalaxy.SQL;
 
 namespace MCGalaxy.Commands.Chatting {

--- a/MCGalaxy/Commands/Information/CmdAbout.cs
+++ b/MCGalaxy/Commands/Information/CmdAbout.cs
@@ -17,7 +17,6 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Data;
 using MCGalaxy.DB;
 using MCGalaxy.Maths;
 using MCGalaxy.SQL;

--- a/MCGalaxy/Commands/Information/CmdOpStats.cs
+++ b/MCGalaxy/Commands/Information/CmdOpStats.cs
@@ -18,7 +18,6 @@
     permissions and limitations under the Licenses.
  */
 using System;
-using System.Data;
 using MCGalaxy.DB;
 using MCGalaxy.SQL;
 

--- a/MCGalaxy/Commands/Information/CmdTop.cs
+++ b/MCGalaxy/Commands/Information/CmdTop.cs
@@ -17,7 +17,6 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Data;
 using MCGalaxy.DB;
 using MCGalaxy.SQL;
 

--- a/MCGalaxy/Commands/Information/CmdWhoNick.cs
+++ b/MCGalaxy/Commands/Information/CmdWhoNick.cs
@@ -15,7 +15,6 @@
     or implied. See the Licenses for the specific language governing
     permissions and limitations under the Licenses.
  */
-using System.Data;
 using MCGalaxy.SQL;
 
 namespace MCGalaxy.Commands.Info {

--- a/MCGalaxy/Commands/Maintenance/CmdPlayerEdit.cs
+++ b/MCGalaxy/Commands/Maintenance/CmdPlayerEdit.cs
@@ -16,7 +16,6 @@
     permissions and limitations under the Licenses.
  */
 using System;
-using System.Data;
 using System.Net;
 using MCGalaxy.DB;
 using MCGalaxy.SQL;

--- a/MCGalaxy/Commands/building/CmdMessageBlock.cs
+++ b/MCGalaxy/Commands/building/CmdMessageBlock.cs
@@ -17,7 +17,6 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Data;
 using MCGalaxy.Blocks;
 using MCGalaxy.Blocks.Extended;
 using MCGalaxy.Maths;

--- a/MCGalaxy/Commands/building/CmdPortal.cs
+++ b/MCGalaxy/Commands/building/CmdPortal.cs
@@ -17,7 +17,6 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Data;
 using MCGalaxy.Blocks;
 using MCGalaxy.Blocks.Extended;
 using MCGalaxy.Maths;

--- a/MCGalaxy/Database/Backends/Interfaces.cs
+++ b/MCGalaxy/Database/Backends/Interfaces.cs
@@ -1,0 +1,112 @@
+﻿/*
+    Copyright 2015 MCGalaxy
+    
+    Dual-licensed under the Educational Community License, Version 2.0 and
+    the GNU General Public License, Version 3 (the "Licenses"); you may
+    not use this file except in compliance with the Licenses. You may
+    obtain a copy of the Licenses at
+    
+    http://www.osedu.org/licenses/ECL-2.0
+    http://www.gnu.org/licenses/gpl-3.0.html
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the Licenses are distributed on an "AS IS"
+    BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the Licenses for the specific language governing
+    permissions and limitations under the Licenses.
+ */
+using System;
+
+namespace MCGalaxy.SQL
+{
+    /// <summary> Abstracts a connection to a SQL database </summary>
+    public abstract class ISqlConnection : IDisposable
+    {
+        public abstract ISqlTransaction BeginTransaction();
+        public abstract ISqlCommand CreateCommand(string sql);
+
+        public abstract void Open();
+        public abstract void ChangeDatabase(string name);
+        public abstract void Close();
+        public abstract void Dispose();
+    }
+
+    /// <summary> Abstracts a SQL command/statement </summary>
+    public abstract class ISqlCommand : IDisposable
+    {
+        public abstract void ClearParameters();
+        public abstract void AddParameter(string name, object value);
+
+        public abstract void Prepare();
+        /// <summary> Executes this command and returns the number of rows affected </summary>
+        public abstract int ExecuteNonQuery();
+        /// <summary> Executes this command and returns an ISqlReader for reading the results </summary>
+        public abstract ISqlReader ExecuteReader();
+        public abstract void Dispose();
+    }
+
+    public abstract class ISqlTransaction : IDisposable
+    {
+        public abstract void Commit();
+        public abstract void Rollback();
+        public abstract void Dispose();
+    }
+
+    /// <summary> Abstracts iterating over the results from executing a SQL command </summary>
+    public abstract class ISqlReader : ISqlRecord, IDisposable
+    {
+        public abstract int RowsAffected { get; }
+        public abstract void Close();
+        public abstract bool Read();
+        public abstract void Dispose();
+    }
+
+    public abstract class ISqlRecord
+    {
+        public abstract int FieldCount { get; }
+        public abstract string GetName(int i);
+        public abstract Type GetFieldType(int i);
+        public abstract int GetOrdinal(string name);
+
+        public abstract byte[] GetBytes(int i);
+        public abstract object GetValue(int i);
+        public abstract bool GetBoolean(int i);
+        public abstract int GetInt32(int i);
+        public abstract long GetInt64(int i);
+        public abstract double GetDouble(int i);
+        public abstract string GetString(int i);
+        public abstract DateTime GetDateTime(int i);
+        public abstract bool IsDBNull(int i);
+
+
+        public string GetText(int col) {
+            return IsDBNull(col) ? "" : GetString(col);
+        }
+
+        public string GetText(string name) {
+            int col = GetOrdinal(name);
+            return IsDBNull(col) ? "" : GetString(col);
+        }
+
+        public int GetInt(string name) {
+            int col = GetOrdinal(name);
+            return IsDBNull(col) ? 0 : GetInt32(col);
+        }
+
+        public long GetLong(string name) {
+            int col = GetOrdinal(name);
+            return IsDBNull(col) ? 0 : GetInt64(col);
+        }
+
+        public string GetStringValue(int col) {
+            if (IsDBNull(col)) return "";
+            Type type = GetFieldType(col);
+            
+            if (type == typeof(string)) return GetString(col);
+            if (type == typeof(DateTime)) {
+                return Database.Backend.RawGetDateTime(this, col);
+            }
+            return GetValue(col).ToString();
+        } 
+    }
+}

--- a/MCGalaxy/Database/Backends/MySQL.cs
+++ b/MCGalaxy/Database/Backends/MySQL.cs
@@ -38,19 +38,13 @@ namespace MCGalaxy.SQL
         public override bool MultipleSchema { get { return true; } }
         public override string EngineName { get { return "MySQL"; } }
         
-        internal override IDbConnection CreateConnection() {
+        public override ISqlConnection CreateConnection() {
             const string format = "Data Source={0};Port={1};User ID={2};Password={3};Pooling={4};Treat Tiny As Boolean=false;";
             string str = string.Format(format, Server.Config.MySQLHost, Server.Config.MySQLPort,
                                        Server.Config.MySQLUsername, Server.Config.MySQLPassword, Server.Config.DatabasePooling);
-            return new MySqlConnection(str);
-        }
-        
-        internal override IDbCommand CreateCommand(string sql, IDbConnection conn) {
-            return new MySqlCommand(sql, (MySqlConnection)conn);
-        }
-        
-        internal override IDbDataParameter CreateParameter() {
-            return new MySqlParameter();
+
+            MySqlConnection conn = new MySqlConnection(str);
+            return new MySQLConnection(conn);
         }
 
         
@@ -63,7 +57,7 @@ namespace MCGalaxy.SQL
             Database.Do(sql, true, null, null);
         }
         
-        public override string RawGetDateTime(IDataRecord record, int col) {
+        public override string RawGetDateTime(ISqlRecord record, int col) {
             DateTime date = record.GetDateTime(col);
             return date.ToString(Database.DateFormat);
         }
@@ -168,6 +162,88 @@ namespace MCGalaxy.SQL
         public override string AddOrReplaceRowSql(string table, string columns, object[] args) {
             return InsertSql("REPLACE INTO", table, columns, args);
         }
+    }
+
+    sealed class MySQLConnection : ISqlConnection 
+    {
+        public readonly MySqlConnection conn;        
+        public MySQLConnection(MySqlConnection conn) { this.conn = conn; }
+
+        public override ISqlTransaction BeginTransaction() {
+            MySqlTransaction trn = conn.BeginTransaction();
+            return new MySQLTransaction(trn);
+        }
+
+        public override ISqlCommand CreateCommand(string sql) {
+            MySqlCommand cmd = new MySqlCommand(sql, conn);
+            return new MySQLCommand(cmd);
+        }
+
+        public override void Open() { conn.Open(); }
+        public override void ChangeDatabase(string name) { conn.ChangeDatabase(name); }
+        public override void Close() { conn.Close(); }
+        public override void Dispose() { conn.Dispose(); }
+    }
+
+    sealed class MySQLCommand : ISqlCommand
+    {        
+        readonly MySqlCommand cmd;
+        public MySQLCommand(MySqlCommand cmd) { this.cmd = cmd; }
+
+        public override void ClearParameters() { 
+            cmd.Parameters.Clear(); 
+        }
+        public override void AddParameter(string name, object value) {
+            cmd.Parameters.AddWithValue(name, value);
+        }
+
+        public override void Dispose() { cmd.Dispose(); }
+        public override void Prepare() { cmd.Prepare(); }
+        public override int ExecuteNonQuery() { return cmd.ExecuteNonQuery(); }
+
+        public override ISqlReader ExecuteReader() { 
+            MySqlDataReader rdr = cmd.ExecuteReader();
+            return new MySQLReader(rdr);
+        }
+    }
+
+    sealed class MySQLTransaction : ISqlTransaction
+    {
+        readonly MySqlTransaction trn;
+        public MySQLTransaction(MySqlTransaction trn) { this.trn = trn; }        
+
+        public override void Commit()   { trn.Commit(); }
+        public override void Rollback() { trn.Rollback(); }
+        public override void Dispose()  { trn.Dispose(); }
+    }
+
+    sealed class MySQLReader : ISqlReader
+    {
+        readonly MySqlDataReader rdr;
+        public MySQLReader(MySqlDataReader rdr) { this.rdr = rdr; }
+
+        public override int RowsAffected { get { return rdr.RecordsAffected; } }
+        public override void Close()   { rdr.Close(); }
+        public override void Dispose() { rdr.Dispose(); }
+        public bool NextResult() { return rdr.NextResult(); } // TODO do we need to call this?
+        public override bool Read()    { return rdr.Read(); }
+
+
+        public override int FieldCount { get  { return rdr.FieldCount; } }
+        public override string GetName(int i) { return rdr.GetName(i); }
+        public override Type GetFieldType(int i) { return rdr.GetFieldType(i); }
+        public override int GetOrdinal(string name) { return rdr.GetOrdinal(name); }
+
+        public override object GetValue(int i)   { return rdr.GetValue(i); }
+
+        public override bool GetBoolean(int i)  { return rdr.GetBoolean(i); }
+        public override byte[] GetBytes(int i)  { return null; }
+        public override int GetInt32(int i)     { return rdr.GetInt32(i); }
+        public override long GetInt64(int i)    { return rdr.GetInt64(i); }
+        public override double GetDouble(int i) { return rdr.GetDouble(i); }
+        public override string GetString(int i) { return rdr.GetString(i); }
+        public override DateTime GetDateTime(int i) { return rdr.GetDateTime(i); }
+        public override bool IsDBNull(int i)    { return rdr.IsDBNull(i); }
     }
 }
 #endif

--- a/MCGalaxy/Database/Backends/SQLite.cs
+++ b/MCGalaxy/Database/Backends/SQLite.cs
@@ -35,16 +35,8 @@ namespace MCGalaxy.SQL
         public override bool MultipleSchema { get { return false; } }
         public override string EngineName { get { return "SQLite"; } }
         
-        internal override IDbConnection CreateConnection() {
+        public override ISqlConnection CreateConnection() {
             return new MCGSQLiteConnection();
-        }
-        
-        internal override IDbCommand CreateCommand(string sql, IDbConnection conn) {
-            return new SQLiteCommand(sql, (SQLiteConnection)conn);
-        }
-        
-        internal override IDbDataParameter CreateParameter() {
-            return new SQLiteParameter();
         }
 
 
@@ -67,7 +59,7 @@ namespace MCGalaxy.SQL
 
         public override void CreateDatabase() { }
         
-        public override string RawGetDateTime(IDataRecord record, int col) {
+        public override string RawGetDateTime(ISqlRecord record, int col) {
             return record.GetString(col); // reader.GetDateTime is extremely slow so avoid it
         }
         
@@ -146,7 +138,8 @@ namespace MCGalaxy.SQL
         }
     }
     
-    public sealed class MCGSQLiteConnection : SQLiteConnection {
+    sealed class MCGSQLiteConnection : SQLiteConnection 
+    {
         protected override bool ConnectionPooling { get { return Server.Config.DatabasePooling; } }
         protected override string DBPath { get { return "MCGalaxy.db"; } }
     }

--- a/MCGalaxy/Database/BlockDB/BlockDBChange.cs
+++ b/MCGalaxy/Database/BlockDB/BlockDBChange.cs
@@ -16,7 +16,6 @@
     permissions and limitations under the Licenses.
  */
 using System;
-using System.Data;
 using MCGalaxy.Blocks.Extended;
 using MCGalaxy.SQL;
 using BlockID = System.UInt16;

--- a/MCGalaxy/Database/BlockDB/BlockDBTableDumper.cs
+++ b/MCGalaxy/Database/BlockDB/BlockDBTableDumper.cs
@@ -17,7 +17,6 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.IO;
 using MCGalaxy.Levels.IO;
 using MCGalaxy.Maths;
@@ -58,7 +57,7 @@ namespace MCGalaxy.DB {
             Database.DeleteTable(table);
         }
         
-        void DumpRow(IDataRecord record) {
+        void DumpRow(ISqlRecord record) {
             if (errorOccurred) return;
             
             try {
@@ -123,10 +122,10 @@ namespace MCGalaxy.DB {
         }
         
         
-        void UpdateBlock(IDataRecord record) {
-            entry.OldRaw = Block.Invalid;
-            entry.NewRaw = record.GetByte(5);
-            byte blockFlags = record.GetByte(6);
+        void UpdateBlock(ISqlRecord record) {
+            entry.OldRaw    = Block.Invalid;
+            entry.NewRaw    = (byte)record.GetInt32(5);
+            byte blockFlags = (byte)record.GetInt32(6);
             entry.Flags = BlockDBFlags.ManualPlace;
             
             if ((blockFlags & 1) != 0) { // deleted block
@@ -137,14 +136,14 @@ namespace MCGalaxy.DB {
             }
         }
         
-        void UpdateCoords(IDataRecord record) {
+        void UpdateCoords(ISqlRecord record) {
             int x = record.GetInt32(2);
             int y = record.GetInt32(3);
             int z = record.GetInt32(4);
             entry.Index = x + dims.X * (z + dims.Z * y);
         }
         
-        void UpdatePlayerID(IDataRecord record) {
+        void UpdatePlayerID(ISqlRecord record) {
             int id;
             string user = record.GetString(0);
             if (!nameCache.TryGetValue(user, out id)) {
@@ -158,7 +157,7 @@ namespace MCGalaxy.DB {
             entry.PlayerID = id;
         }
         
-        void UpdateTimestamp(IDataRecord record) {
+        void UpdateTimestamp(ISqlRecord record) {
             // date is in format yyyy-MM-dd hh:mm:ss
             string date = Database.Backend.RawGetDateTime(record, 1);
             int year =  (date[0] - '0') * 1000 + (date[1] - '0') * 100 + (date[2] - '0') * 10 + (date[3] - '0');

--- a/MCGalaxy/Database/BlockDB/NameConverter.cs
+++ b/MCGalaxy/Database/BlockDB/NameConverter.cs
@@ -17,7 +17,6 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Data;
 using MCGalaxy.SQL;
 
 namespace MCGalaxy.DB {

--- a/MCGalaxy/Database/Database.cs
+++ b/MCGalaxy/Database/Database.cs
@@ -17,12 +17,11 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Data;
 
 namespace MCGalaxy.SQL 
 {
     /// <summary> Callback function invoked on a row returned from an SQL query. </summary>
-    public delegate void ReaderCallback(IDataRecord record);
+    public delegate void ReaderCallback(ISqlRecord record);
     
     /// <summary> Abstracts a SQL database management engine. </summary>
     public static class Database 
@@ -51,7 +50,7 @@ namespace MCGalaxy.SQL
             return value;
         }
         
-        internal static string[] ParseFields(IDataRecord record) {
+        internal static string[] ParseFields(ISqlRecord record) {
             string[] field = new string[record.FieldCount];
             for (int i = 0; i < field.Length; i++) { field[i] = record.GetStringValue(i); }
             return field;
@@ -223,38 +222,5 @@ namespace MCGalaxy.SQL
             Backend = Server.Config.UseMySQL ? MySQLBackend.Instance : SQLiteBackend.Instance;
 #endif
         }
-    }
-    
-    public static class DatabaseExts 
-    {
-        public static string GetText(this IDataRecord record, int col) {
-            return record.IsDBNull(col) ? "" : record.GetString(col);
-        }
-
-        public static string GetText(this IDataRecord record, string name) {
-            int col = record.GetOrdinal(name);
-            return record.IsDBNull(col) ? "" : record.GetString(col);
-        }
-
-        public static int GetInt(this IDataRecord record, string name) {
-            int col = record.GetOrdinal(name);
-            return record.IsDBNull(col) ? 0 : record.GetInt32(col);
-        }
-
-        public static long GetLong(this IDataRecord record, string name) {
-            int col = record.GetOrdinal(name);
-            return record.IsDBNull(col) ? 0 : record.GetInt64(col);
-        }
-
-        public static string GetStringValue(this IDataRecord record, int col) {
-            if (record.IsDBNull(col)) return "";
-            Type type = record.GetFieldType(col);
-            
-            if (type == typeof(string)) return record.GetString(col);
-            if (type == typeof(DateTime)) {
-                return Database.Backend.RawGetDateTime(record, col);
-            }
-            return record.GetValue(col).ToString();
-        }        
     }
 }

--- a/MCGalaxy/Database/PlayerDB.cs
+++ b/MCGalaxy/Database/PlayerDB.cs
@@ -17,7 +17,6 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.IO;
 using MCGalaxy.SQL;
 

--- a/MCGalaxy/Database/PlayerData.cs
+++ b/MCGalaxy/Database/PlayerData.cs
@@ -16,7 +16,6 @@
     permissions and limitations under the Licenses.
  */
 using System;
-using System.Data;
 using MCGalaxy.SQL;
 
 namespace MCGalaxy.DB {
@@ -99,7 +98,7 @@ namespace MCGalaxy.DB {
             p.TimesBeenKicked = Kicks;
         }
         
-        internal static PlayerData Parse(IDataRecord record) {
+        internal static PlayerData Parse(ISqlRecord record) {
             PlayerData data = new PlayerData();
             data.Name = record.GetText(ColumnName);
             data.IP   = record.GetText(ColumnIP);
@@ -154,7 +153,7 @@ namespace MCGalaxy.DB {
             return Colors.Name(raw).Length == 0 ? "" : raw;
         }
         
-        static DateTime ParseDateTime(IDataRecord record, string name) {
+        static DateTime ParseDateTime(ISqlRecord record, string name) {
             int i = record.GetOrdinal(name);
             // dates are a major pain
             try {

--- a/MCGalaxy/Database/SqlTransaction.cs
+++ b/MCGalaxy/Database/SqlTransaction.cs
@@ -16,14 +16,13 @@
     permissions and limitations under the Licenses.
  */
 using System;
-using System.Data;
 
 namespace MCGalaxy.SQL 
 {    
     public sealed class SqlTransaction : IDisposable 
     {
-        internal IDbConnection conn;
-        internal IDbTransaction transaction;
+        internal ISqlConnection conn;
+        internal ISqlTransaction transaction;
         
         public SqlTransaction() {
             IDatabaseBackend db = Database.Backend;
@@ -65,8 +64,7 @@ namespace MCGalaxy.SQL
         public bool Execute(string sql, params object[] args) {
             IDatabaseBackend db = Database.Backend;
             try {
-                using (IDbCommand cmd = db.CreateCommand(sql, conn)) {
-                    cmd.Transaction = transaction;
+                using (ISqlCommand cmd = conn.CreateCommand(sql)) {
                     db.FillParams(cmd, args);
                     cmd.ExecuteNonQuery();
                     return true;

--- a/MCGalaxy/Database/TableDumper.cs
+++ b/MCGalaxy/Database/TableDumper.cs
@@ -16,7 +16,6 @@
     permissions and limitations under the Licenses.
  */
 using System;
-using System.Data;
 using System.IO;
 
 namespace MCGalaxy.SQL 
@@ -40,7 +39,7 @@ namespace MCGalaxy.SQL
             }
         }
         
-        void MakeInsertFormat(IDataRecord record) {
+        void MakeInsertFormat(ISqlRecord record) {
             sql.WriteLine("--");
             sql.WriteLine("-- Dumping data for table `{0}`", table);
             sql.WriteLine("--");
@@ -56,7 +55,7 @@ namespace MCGalaxy.SQL
             gottenRows = true;
         }
         
-        void DumpRow(IDataRecord record) {
+        void DumpRow(ISqlRecord record) {
             if (!gottenRows) MakeInsertFormat(record);
             sql.WriteLine(insertCols);
 

--- a/MCGalaxy/Economy/Economy.DB.cs
+++ b/MCGalaxy/Economy/Economy.DB.cs
@@ -17,7 +17,6 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Data;
 using MCGalaxy.DB;
 using MCGalaxy.SQL;
 
@@ -34,7 +33,7 @@ namespace MCGalaxy.Eco {
             new ColumnDesc("fine", ColumnType.VarChar, 255),
         };
         
-        static EcoStats ParseOld(IDataRecord record) {
+        static EcoStats ParseOld(ISqlRecord record) {
             EcoStats stats = ParseStats(record);
             stats.__unused = record.GetInt("money");
             return stats;
@@ -79,7 +78,7 @@ namespace MCGalaxy.Eco {
                                      stats.Payment, stats.Salary, stats.Fine);
         }
         
-        static EcoStats ParseStats(IDataRecord record) {
+        static EcoStats ParseStats(ISqlRecord record) {
             EcoStats stats;
             stats.Player = record.GetText("player");
             stats.Payment  = Parse(record.GetText("payment"));

--- a/MCGalaxy/Games/CTF/CtfGame.DB.cs
+++ b/MCGalaxy/Games/CTF/CtfGame.DB.cs
@@ -18,7 +18,6 @@
     permissions and limitations under the Licenses.
  */
 using System;
-using System.Data;
 using MCGalaxy.SQL;
 
 namespace MCGalaxy.Games {
@@ -35,7 +34,7 @@ namespace MCGalaxy.Games {
             new ColumnDesc("tags", ColumnType.UInt24),
         };
         
-        static CtfStats ParseStats(IDataRecord record) {
+        static CtfStats ParseStats(ISqlRecord record) {
             CtfStats stats;
             stats.Points   = record.GetInt("Points");
             stats.Captures = record.GetInt("Captures");

--- a/MCGalaxy/Games/ZombieSurvival/ZSGame.DB.cs
+++ b/MCGalaxy/Games/ZombieSurvival/ZSGame.DB.cs
@@ -17,7 +17,6 @@
     permissions and limitations under the Licenses.
  */
 using System;
-using System.Data;
 using MCGalaxy.DB;
 using MCGalaxy.SQL;
 
@@ -103,7 +102,7 @@ namespace MCGalaxy.Games {
             new ColumnDesc("Additional1", ColumnType.Int32),
         };
         
-        static ZombieStats ParseStats(IDataRecord record) {
+        static ZombieStats ParseStats(ISqlRecord record) {
             ZombieStats stats;
             stats.TotalRounds   = record.GetInt("TotalRounds");
             stats.MaxRounds     = record.GetInt("MaxRounds");

--- a/MCGalaxy/Levels/LevelDB.cs
+++ b/MCGalaxy/Levels/LevelDB.cs
@@ -17,7 +17,6 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Data;
 using MCGalaxy.Blocks.Extended;
 using MCGalaxy.Maths;
 using MCGalaxy.SQL;
@@ -40,7 +39,7 @@ namespace MCGalaxy {
             Logger.Log(LogType.BackgroundActivity, "Saved BlockDB changes for: {0}", lvl.name);
         }
 
-        static Zone ParseZone(IDataRecord record) {
+        static Zone ParseZone(ISqlRecord record) {
             Zone z = new Zone();
             z.MinX = (ushort)record.GetInt("SmallX");
             z.MinY = (ushort)record.GetInt("SmallY");

--- a/MCGalaxy/MCGalaxy_.csproj
+++ b/MCGalaxy/MCGalaxy_.csproj
@@ -379,6 +379,7 @@
     <Compile Include="CorePlugin\EcoHandlers.cs" />
     <Compile Include="CorePlugin\MiscHandlers.cs" />
     <Compile Include="CorePlugin\ModActionHandler.cs" />
+    <Compile Include="Database\Backends\Interfaces.cs" />
     <Compile Include="Database\Backends\SQLite.cs" />
     <Compile Include="Database\Backends\SQLiteBackend.cs" />
     <Compile Include="Database\BlockDB\BlockDB.cs" />

--- a/MCGalaxy/Player/PlayerInfo.cs
+++ b/MCGalaxy/Player/PlayerInfo.cs
@@ -15,7 +15,6 @@ permissions and limitations under the Licenses.
 
 using System;
 using System.Collections.Generic;
-using System.Data;
 using MCGalaxy.DB;
 using MCGalaxy.SQL;
 
@@ -97,7 +96,7 @@ namespace MCGalaxy
         }
 
         
-        static void ReadAccounts(IDataRecord record, List<string> names) {
+        static void ReadAccounts(ISqlRecord record, List<string> names) {
             string name = record.GetText(0);         
             if (!names.CaselessContains(name)) names.Add(name);
         }

--- a/MCGalaxy/Server/Server.DB.cs
+++ b/MCGalaxy/Server/Server.DB.cs
@@ -17,7 +17,6 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.IO;
 using MCGalaxy.SQL;
 

--- a/MCGalaxy/Server/Tasks/UpgradeTasks.cs
+++ b/MCGalaxy/Server/Tasks/UpgradeTasks.cs
@@ -17,7 +17,6 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.IO;
 using MCGalaxy.Bots;
 using MCGalaxy.SQL;
@@ -91,7 +90,7 @@ namespace MCGalaxy.Tasks {
             Database.ReadRows("Players", "ID,TimeSpent", ReadTimeSpent);
         }
         
-        static void ReadTimeSpent(IDataRecord record) {
+        static void ReadTimeSpent(ISqlRecord record) {
             playerCount++;
             try {
                 int id = record.GetInt32(0);


### PR DESCRIPTION
Two main advantages
* Reduces size of standalone MCGalaxy build by 3 MB
* MCGalaxy can now run with the bare minimum of `mono-runtime` (used to immediately crash previously due to lack of `System.Data.dll` since `libmono-system-data4.0-cil` package is not a part of `mono-runtime`)

Some minor benefits
* Plugins don't need to remember to use `//reference System.Data.dll` anymore
* Uses ~1 MB less memory on Windows