### PR TITLE
Imageprint improvements

### DIFF
--- a/MCGalaxy/Drawing/Image/IPaletteMatcher.cs
+++ b/MCGalaxy/Drawing/Image/IPaletteMatcher.cs
@@ -27,7 +27,6 @@ namespace MCGalaxy.Drawing
         BlockID BestMatch(byte R, byte G, byte B);
         BlockID BestMatch(byte R, byte G, byte B, out Pixel pixel);
         BlockID BestMatch(byte R, byte G, byte B, out bool backLayer);
-        BlockID BestMatch(byte R, byte G, byte B, out bool backLayer, out Pixel pixel);
     }
     
     public sealed class RgbPaletteMatcher : IPaletteMatcher 
@@ -57,18 +56,6 @@ namespace MCGalaxy.Drawing
             
             backLayer = backDist < frontDist;
             return backLayer ? back[backPos].Block : front[frontPos].Block;
-        }
-        public BlockID BestMatch(byte R, byte G, byte B, out bool backLayer, out Pixel pixel) {
-            int pos, frontPos, backPos;
-            int frontDist = MinDist(R, G, B, front, out frontPos);
-            int backDist = MinDist(R, G, B, back, out backPos);
-
-            backLayer = backDist < frontDist;
-            PaletteEntry[] palette = backLayer ? back : front;
-            pos = backLayer ? backPos : frontPos;
-
-            pixel = new Pixel(); pixel.A = byte.MaxValue; pixel.R = palette[pos].R; pixel.G = palette[pos].G; pixel.B = palette[pos].B;
-            return palette[pos].Block;
         }
 
         static int MinDist(byte R, byte G, byte B, PaletteEntry[] entries, out int pos) {
@@ -118,9 +105,6 @@ namespace MCGalaxy.Drawing
         public BlockID BestMatch(byte R, byte G, byte B, out bool backLayer) {
             backLayer = false;
             return BestMatch(R, G, B);
-        }
-        public ushort BestMatch(byte R, byte G, byte B, out bool backLayer, out Pixel pixel) {
-            throw new NotImplementedException();
         }
 
         struct LabColor {

--- a/MCGalaxy/Drawing/Image/IPaletteMatcher.cs
+++ b/MCGalaxy/Drawing/Image/IPaletteMatcher.cs
@@ -17,6 +17,7 @@
  */
 using System;
 using BlockID = System.UInt16;
+using MCGalaxy.Util;
 
 namespace MCGalaxy.Drawing 
 {
@@ -24,7 +25,9 @@ namespace MCGalaxy.Drawing
     {
         void SetPalette(PaletteEntry[] front, PaletteEntry[] back);
         BlockID BestMatch(byte R, byte G, byte B);
+        BlockID BestMatch(byte R, byte G, byte B, out Pixel pixel);
         BlockID BestMatch(byte R, byte G, byte B, out bool backLayer);
+        BlockID BestMatch(byte R, byte G, byte B, out bool backLayer, out Pixel pixel);
     }
     
     public sealed class RgbPaletteMatcher : IPaletteMatcher 
@@ -39,7 +42,14 @@ namespace MCGalaxy.Drawing
             MinDist(R, G, B, front, out pos);
             return front[pos].Block;
         }
-        
+        public BlockID BestMatch(byte R, byte G, byte B, out Pixel pixel) {
+            int pos;
+            MinDist(R, G, B, front, out pos);
+            pixel = new Pixel(); pixel.A = byte.MaxValue; pixel.R = front[pos].R; pixel.G = front[pos].G; pixel.B = front[pos].B;
+            return front[pos].Block;
+        }
+
+
         public BlockID BestMatch(byte R, byte G, byte B, out bool backLayer) {
             int frontPos, backPos;
             int frontDist = MinDist(R, G, B, front, out frontPos);
@@ -48,8 +58,19 @@ namespace MCGalaxy.Drawing
             backLayer = backDist < frontDist;
             return backLayer ? back[backPos].Block : front[frontPos].Block;
         }
-        
-        
+        public BlockID BestMatch(byte R, byte G, byte B, out bool backLayer, out Pixel pixel) {
+            int pos, frontPos, backPos;
+            int frontDist = MinDist(R, G, B, front, out frontPos);
+            int backDist = MinDist(R, G, B, back, out backPos);
+
+            backLayer = backDist < frontDist;
+            PaletteEntry[] palette = backLayer ? back : front;
+            pos = backLayer ? backPos : frontPos;
+
+            pixel = new Pixel(); pixel.A = byte.MaxValue; pixel.R = palette[pos].R; pixel.G = palette[pos].G; pixel.B = palette[pos].B;
+            return palette[pos].Block;
+        }
+
         static int MinDist(byte R, byte G, byte B, PaletteEntry[] entries, out int pos) {
             int minDist = int.MaxValue; pos = 0;
             for (int i = 0; i < entries.Length; i++) {
@@ -89,13 +110,19 @@ namespace MCGalaxy.Drawing
             }
             return palette[pos].Block;
         }
+
+        public BlockID BestMatch(byte R, byte G, byte B, out Pixel pixel) {
+            throw new NotImplementedException();
+        }
         
         public BlockID BestMatch(byte R, byte G, byte B, out bool backLayer) {
             backLayer = false;
             return BestMatch(R, G, B);
         }
-        
-        
+        public ushort BestMatch(byte R, byte G, byte B, out bool backLayer, out Pixel pixel) {
+            throw new NotImplementedException();
+        }
+
         struct LabColor {
             public double L, A, B;
             public BlockID Block;

--- a/MCGalaxy/Drawing/Image/ImagePrintDrawOp.cs
+++ b/MCGalaxy/Drawing/Image/ImagePrintDrawOp.cs
@@ -196,13 +196,7 @@ namespace MCGalaxy.Drawing.Ops
                         oldClampedG = (byte)Utils.Clamp((int)oldPixel.Y, byte.MinValue, byte.MaxValue);
                         oldClampedB = (byte)Utils.Clamp((int)oldPixel.Z, byte.MinValue, byte.MaxValue);
                         Pixel temp;
-                        if (!DualLayer) {
-                            selector.BestMatch(oldClampedR, oldClampedG, oldClampedB, out temp);
-                        } else {
-                            bool backLayer;
-                            selector.BestMatch(oldClampedR, oldClampedG, oldClampedB, out backLayer, out temp);
-                        }
-                        
+                        selector.BestMatch(oldClampedR, oldClampedG, oldClampedB, out temp);
                         newPixel = new Vec3F32(temp.R, temp.G, temp.B);
                     }
 
@@ -226,16 +220,7 @@ namespace MCGalaxy.Drawing.Ops
                     if (P.A < 20) { output(Place(x, y, z, Block.Air)); continue; }
 
                     BlockID block;
-                    if (!DualLayer) {
-                        block = selector.BestMatch(P.R, P.G, P.B);
-                    } else {
-                        bool backLayer;
-                        block = selector.BestMatch(P.R, P.G, P.B, out backLayer);
-                        if (!backLayer) {
-                            x = (ushort)(x - adj.X);
-                            z = (ushort)(z - adj.Z);
-                        }
-                    }
+                    block = selector.BestMatch(P.R, P.G, P.B);
                     output(Place(x, y, z, block));
                 }
         }

--- a/MCGalaxy/Drawing/Image/ImagePrintDrawOp.cs
+++ b/MCGalaxy/Drawing/Image/ImagePrintDrawOp.cs
@@ -36,7 +36,7 @@ namespace MCGalaxy.Drawing.Ops
         public ImagePalette Palette;
         
         internal Vec3S32 dx, dy, adj;
-        IPaletteMatcher selector;
+        protected IPaletteMatcher selector;
         
         public override void Perform(Vec3S32[] marks, Brush brush, DrawOpOutput output) {
             selector = new RgbPaletteMatcher();
@@ -52,13 +52,13 @@ namespace MCGalaxy.Drawing.Ops
             
             // Put all the blocks in shadow
             if (DualLayer) {
-                ushort y = (ushort)(Origin.Y + Source.Height);
+                ushort y = (ushort)Math.Min(Origin.Y + Source.Height, Level.Height-1);
                 for (int i = 0; i < Source.Width; i++) {
                     ushort x = (ushort)(Origin.X + dx.X * i);
                     ushort z = (ushort)(Origin.Z + dx.Z * i);
                     output(Place(x, y, z, Block.Stone));
                     
-                    x = (ushort)(x + adj.X); z = (ushort)(z + adj.Z);
+                    x = (ushort)(x - adj.X); z = (ushort)(z - adj.Z);
                     output(Place(x, y, z, Block.Stone));
                 }
             }
@@ -103,7 +103,7 @@ namespace MCGalaxy.Drawing.Ops
             return entry;
         }
         
-        void OutputPixels(DrawOpOutput output) {
+        protected virtual void OutputPixels(DrawOpOutput output) {
             int width = Source.Width, height = Source.Height;
             int srcY = height - 1; // need to flip coords in bitmap vertically
             
@@ -122,9 +122,9 @@ namespace MCGalaxy.Drawing.Ops
                 } else {
                     bool backLayer;
                     block = selector.BestMatch(P.R, P.G, P.B, out backLayer);                    
-                    if (backLayer) {
-                        x = (ushort)(x + adj.X);
-                        z = (ushort)(z + adj.Z);
+                    if (!backLayer) {
+                        x = (ushort)(x - adj.X);
+                        z = (ushort)(z - adj.Z);
                     }
                 }
                 output(Place(x, y, z, block));
@@ -162,5 +162,93 @@ namespace MCGalaxy.Drawing.Ops
                 if (dir == 3) dx.Z = -1;
             }
         }
+    }
+    public class ImagePrintDitheredDrawOp : ImagePrintDrawOp
+    {
+        Vec3F32[,] pixels;
+        protected override void OutputPixels(DrawOpOutput output) {
+            int width = Source.Width, height = Source.Height;
+            int srcY = height - 1; // need to flip coords in bitmap vertically
+
+            pixels = new Vec3F32[width, height];
+
+            //setup image
+            for (int y = 0; y < height; y++) {
+                for (int x = 0; x < width; x++) {
+                    Pixel p = Source.Get(x, y);
+                    pixels[x, y] = new Vec3F32(p.R, p.G, p.B);
+                }
+            }
+
+            //dither image
+            for (int y = 0; y < height; y++) {
+                for (int x = 0; x < width; x++) {
+                    Vec3F32 oldPixel = pixels[x, y];
+                    // No Clamp for float?
+                    if (oldPixel.X > 255) { oldPixel.X = 255; } if (oldPixel.X < 0) { oldPixel.X = 0; }
+                    if (oldPixel.Y > 255) { oldPixel.Y = 255; } if (oldPixel.Y < 0) { oldPixel.Y = 0; }
+                    if (oldPixel.Z > 255) { oldPixel.Z = 255; } if (oldPixel.Z < 0) { oldPixel.Z = 0; }
+
+                    Vec3F32 newPixel;
+                    {
+                        byte oldClampedR, oldClampedG, oldClampedB;
+                        oldClampedR = (byte)Utils.Clamp((int)oldPixel.X, byte.MinValue, byte.MaxValue);
+                        oldClampedG = (byte)Utils.Clamp((int)oldPixel.Y, byte.MinValue, byte.MaxValue);
+                        oldClampedB = (byte)Utils.Clamp((int)oldPixel.Z, byte.MinValue, byte.MaxValue);
+                        Pixel temp;
+                        if (!DualLayer) {
+                            selector.BestMatch(oldClampedR, oldClampedG, oldClampedB, out temp);
+                        } else {
+                            bool backLayer;
+                            selector.BestMatch(oldClampedR, oldClampedG, oldClampedB, out backLayer, out temp);
+                        }
+                        
+                        newPixel = new Vec3F32(temp.R, temp.G, temp.B);
+                    }
+
+
+                    pixels[x, y] = newPixel;
+                    Vec3F32 quantError = oldPixel - newPixel;
+                    if (x + 1 < width                  ) pixels[x + 1, y    ] += (7.0f / 16.0f) * quantError;
+                    if (x - 1 > 0     && y + 1 < height) pixels[x - 1, y + 1] += (3.0f / 16.0f) * quantError;
+                    if (y + 1 < height                 ) pixels[x,     y + 1] += (5.0f / 16.0f) * quantError;
+                    if (x + 1 < width && y + 1 < height) pixels[x + 1, y + 1] += (1.0f / 16.0f) * quantError;
+                }
+            }
+
+
+            for (int yy = 0; yy < height; yy++, srcY--)
+                for (int xx = 0; xx < width; xx++) {
+                    Pixel P = GetPixel(xx, srcY);
+                    ushort x = (ushort)(Origin.X + dx.X * xx + dy.X * yy);
+                    ushort y = (ushort)(Origin.Y + dx.Y * xx + dy.Y * yy);
+                    ushort z = (ushort)(Origin.Z + dx.Z * xx + dy.Z * yy);
+                    if (P.A < 20) { output(Place(x, y, z, Block.Air)); continue; }
+
+                    BlockID block;
+                    if (!DualLayer) {
+                        block = selector.BestMatch(P.R, P.G, P.B);
+                    } else {
+                        bool backLayer;
+                        block = selector.BestMatch(P.R, P.G, P.B, out backLayer);
+                        if (!backLayer) {
+                            x = (ushort)(x - adj.X);
+                            z = (ushort)(z - adj.Z);
+                        }
+                    }
+                    output(Place(x, y, z, block));
+                }
+        }
+
+
+        Pixel GetPixel(int x, int y) {
+            Pixel P = Source.Get(x, y);
+            Vec3F32 floatPixel = pixels[x, y];
+            P.R = (byte)Utils.Clamp((int)floatPixel.X, byte.MinValue, byte.MaxValue);
+            P.G = (byte)Utils.Clamp((int)floatPixel.Y, byte.MinValue, byte.MaxValue);
+            P.B = (byte)Utils.Clamp((int)floatPixel.Z, byte.MinValue, byte.MaxValue);
+            return P;
+        }
+
     }
 }


### PR DESCRIPTION
Add dithered mode (floyd-steinberg)
Simplify mode names
In 2layer mode, ensure that the stone shadow strip isn't cut off at the top of the map
In 2layer mode, printing an image at the very edge of the map will no longer cut off the back layer