### PR TITLE
display if user is ip banned along side ip ban reason

### DIFF
--- a/MCGalaxy/CorePlugin/ConnectingHandler.cs
+++ b/MCGalaxy/CorePlugin/ConnectingHandler.cs
@@ -91,7 +91,7 @@ namespace MCGalaxy.Core {
         static bool CheckBanned(Player p) {
             string ipban = Server.bannedIP.Get(p.ip);
             if (ipban != null) {
-                ipban = ipban.Length > 0 ? ipban : Server.Config.DefaultBanMessage;
+                ipban = "IP-Banned: " + ipban.Length > 0 ? ipban : Server.Config.DefaultBanMessage;
                 p.Kick(null, ipban, true);
                 return false;
             }


### PR DESCRIPTION
prevents abusive ip bans where they mask the ip ban by masking it as not whitelisted message

ex: "This server is private!" ip ban reason -> "IP-Banned: This server is private!"