### PR TITLE
Improve Database.UpdateRows/DeleteRows

### DIFF
--- a/MCGalaxy/Blocks/Extended/MessageBlock.cs
+++ b/MCGalaxy/Blocks/Extended/MessageBlock.cs
@@ -166,7 +166,7 @@ namespace MCGalaxy.Blocks.Extended {
             int changed = Database.UpdateRows("Messages" + map, "Message=@3",
                                              "WHERE X=@0 AND Y=@1 AND Z=@2", args);
             if (changed == 0) {
-                Database.AddRow("Messages" + map, "X, Y, Z, Message", args);
+                Database.AddRow("Messages" + map, "X,Y,Z, Message", args);
             }
             
             Level lvl = LevelInfo.FindExact(map);

--- a/MCGalaxy/Blocks/Extended/MessageBlock.cs
+++ b/MCGalaxy/Blocks/Extended/MessageBlock.cs
@@ -160,15 +160,13 @@ namespace MCGalaxy.Blocks.Extended {
             contents = Colors.Escape(contents);
             contents = contents.UnicodeToCp437();
             
-            Database.CreateTable("Messages" + map, LevelDB.createMessages);            
-            int count = Database.CountRows("Messages" + map,
-                                           "WHERE X=@0 AND Y=@1 AND Z=@2", x, y, z);
+            Database.CreateTable("Messages" + map, LevelDB.createMessages);
+            object[] args = new object[] { x, y, z,  contents };
             
-            if (count == 0) {
-                Database.AddRow("Messages" + map, "X, Y, Z, Message", x, y, z, contents);
-            } else {
-                Database.UpdateRows("Messages" + map, "Message=@3",
-                                    "WHERE X=@0 AND Y=@1 AND Z=@2", x, y, z, contents);
+            int changed = Database.UpdateRows("Messages" + map, "Message=@3",
+                                             "WHERE X=@0 AND Y=@1 AND Z=@2", args);
+            if (changed == 0) {
+                Database.AddRow("Messages" + map, "X, Y, Z, Message", args);
             }
             
             Level lvl = LevelInfo.FindExact(map);

--- a/MCGalaxy/Blocks/Extended/Portal.cs
+++ b/MCGalaxy/Blocks/Extended/Portal.cs
@@ -137,16 +137,12 @@ namespace MCGalaxy.Blocks.Extended {
         public static void Set(string map, ushort x, ushort y, ushort z,
                                ushort exitX, ushort exitY, ushort exitZ, string exitMap) {
             Database.CreateTable("Portals" + map, LevelDB.createPortals);
-            int count = Database.CountRows("Portals" + map,
-                                           "WHERE EntryX=@0 AND EntryY=@1 AND EntryZ=@2", x, y, z);
+            object[] args = new object[] { x, y, z,  exitX, exitY, exitZ,  exitMap };
             
-            if (count == 0) {
-                Database.AddRow("Portals" + map, "EntryX, EntryY, EntryZ, ExitX, ExitY, ExitZ, ExitMap",
-                                x, y, z, exitX, exitY, exitZ, exitMap);
-            } else {
-                Database.UpdateRows("Portals" + map, "ExitMap=@6, ExitX=@3, ExitY=@4, ExitZ=@5",
-                                    "WHERE EntryX=@0 AND EntryY=@1 AND EntryZ=@2", x, y, z,
-                                    exitX, exitY, exitZ, exitMap);
+            int changed = Database.UpdateRows("Portals" + map, "ExitX=@3, ExitY=@4, ExitZ=@5, ExitMap=@6",
+                                              "WHERE EntryX=@0 AND EntryY=@1 AND EntryZ=@2", args);
+            if (changed == 0) {
+                Database.AddRow("Portals" + map, "EntryX, EntryY, EntryZ, ExitX, ExitY, ExitZ, ExitMap", args);
             }
             
             Level lvl = LevelInfo.FindExact(map);

--- a/MCGalaxy/Blocks/Extended/Portal.cs
+++ b/MCGalaxy/Blocks/Extended/Portal.cs
@@ -142,7 +142,7 @@ namespace MCGalaxy.Blocks.Extended {
             int changed = Database.UpdateRows("Portals" + map, "ExitX=@3, ExitY=@4, ExitZ=@5, ExitMap=@6",
                                               "WHERE EntryX=@0 AND EntryY=@1 AND EntryZ=@2", args);
             if (changed == 0) {
-                Database.AddRow("Portals" + map, "EntryX, EntryY, EntryZ, ExitX, ExitY, ExitZ, ExitMap", args);
+                Database.AddRow("Portals" + map, "EntryX,EntryY,EntryZ, ExitX,ExitY,ExitZ, ExitMap", args);
             }
             
             Level lvl = LevelInfo.FindExact(map);

--- a/MCGalaxy/Commands/Chat/CmdInbox.cs
+++ b/MCGalaxy/Commands/Chat/CmdInbox.cs
@@ -52,8 +52,8 @@ namespace MCGalaxy.Commands.Chatting
                 if (args.Length == 1) {
                     p.Message("You need to provide either \"all\" or a number."); return;
                 } else if (args[1].CaselessEq("all")) {
-                    Database.DeleteRows("Inbox" + p.name);
-                    p.Message("Deleted all messages.");
+                    int count = Database.DeleteRows("Inbox" + p.name, "");
+                    p.Message("Deleted all {0} messages.", count);
                 } else {
                     DeleteByID(p, args[1], entries);
                 }

--- a/MCGalaxy/Database/Database.cs
+++ b/MCGalaxy/Database/Database.cs
@@ -114,11 +114,13 @@ namespace MCGalaxy.SQL
         
         /// <summary> Inserts/Copies all the rows from the source table into the destination table. </summary>
         /// <remarks> May NOT work correctly if the tables have different schema. </remarks>
-        public static void CopyAllRows(string srcTable, string dstTable) {
+        /// <returns> The number of rows copied </returns>
+        public static int CopyAllRows(string srcTable, string dstTable) {
             ValidateName(srcTable);
             ValidateName(dstTable);
+            
             string sql = Backend.CopyAllRowsSql(srcTable, dstTable);
-            Execute(sql, null);
+            return Execute(sql, null);
         }
         
         /// <summary> Iterates over read rows for the given table. </summary>
@@ -127,30 +129,35 @@ namespace MCGalaxy.SQL
         public static void ReadRows(string table, string columns,
                                     ReaderCallback callback, string modifier = "", params object[] args) {
             ValidateName(table);
+            
             string sql = Backend.ReadRowsSql(table, columns, modifier);
             Iterate(sql, callback, args);
         }
         
-        /// <summary> Updates rows for the given table. </summary>
-        /// <param name="modifier"> Optional SQL to filter which rows are updated. </param>
-        public static void UpdateRows(string table, string columns,
-                                       string modifier = "", params object[] args) {
+        /// <summary> Updates rows for the given table </summary>
+        /// <param name="modifier"> Optional SQL to filter which rows are updated. Can be just "" </param>
+        /// <returns> The number of rows updated </returns>
+        public static int UpdateRows(string table, string columns,
+                                     string modifier, params object[] args) {
             ValidateName(table);
             string sql = Backend.UpdateRowsSql(table, columns, modifier);
-            Execute(sql, args);
+            return Execute(sql, args);
         }
         
         /// <summary> Deletes rows for the given table. </summary>
-        /// <param name="modifier"> Optional SQL to filter which rows are deleted. </param>
-        public static void DeleteRows(string table, string modifier = "", params object[] args) {
+        /// <param name="modifier"> Optional SQL to filter which rows are deleted. Can be just "" </param>
+        /// <returns> The number of rows deleted </returns>
+        public static int DeleteRows(string table, string modifier, params object[] args) {
             ValidateName(table);
+            
             string sql = Backend.DeleteRowsSql(table, modifier);
-            Execute(sql, args);
+            return Execute(sql, args);
         }
 
         /// <summary> Adds a row to the given table. </summary>
         public static void AddRow(string table, string columns, params object[] args) {
             ValidateName(table);
+            
             string sql = Backend.AddRowSql(table, columns, args.Length);
             Execute(sql, args);
         }
@@ -158,6 +165,7 @@ namespace MCGalaxy.SQL
         /// <summary> Adds or replaces a row (same primary key) in the given table. </summary>
         public static void AddOrReplaceRow(string table, string columns, params object[] args) {
             ValidateName(table);
+            
             string sql = Backend.AddOrReplaceRowSql(table, columns, args.Length);
             Execute(sql, args);
         }

--- a/MCGalaxy/Modules/Games/CTF/CmdCtf.cs
+++ b/MCGalaxy/Modules/Games/CTF/CmdCtf.cs
@@ -24,7 +24,7 @@ using BlockID = System.UInt16;
 
 namespace MCGalaxy.Modules.Games.CTF
 {
-    public sealed class CmdCTF : RoundsGameCmd 
+    sealed class CmdCTF : RoundsGameCmd 
     {
         public override string name { get { return "CTF"; } }
         public override string shortcut { get { return "CTFSetup"; } }

--- a/MCGalaxy/Modules/Games/CTF/CtfGame.DB.cs
+++ b/MCGalaxy/Modules/Games/CTF/CtfGame.DB.cs
@@ -55,13 +55,15 @@ namespace MCGalaxy.Modules.Games.CTF
             CtfData data = TryGet(p);
             if (data == null || data.Points == 0 && data.Captures == 0 && data.Tags == 0) return;
             
-            int count = Database.CountRows("CTF", "WHERE Name=@0", p.name);
-            if (count == 0) {
-                Database.AddRow("CTF", "Points, Captures, tags, Name",
-                                data.Points, data.Captures, data.Tags, p.name);
-            } else {
-                Database.UpdateRows("CTF", "Points=@0, Captures=@1, tags=@2", "WHERE Name=@3",
-                                    data.Points, data.Captures, data.Tags, p.name);
+            object[] args = new object[] {
+            	 data.Points, data.Captures, data.Tags, 
+            	 p.name
+            };
+            
+            int changed = Database.UpdateRows("CTF", "Points=@0, Captures=@1, tags=@2", 
+                                              "WHERE Name=@3", args);
+            if (changed == 0) {
+                Database.AddRow("CTF", "Points, Captures, tags, Name", args);
             }
         }
     }

--- a/MCGalaxy/Modules/Games/Countdown/CmdCountdown.cs
+++ b/MCGalaxy/Modules/Games/Countdown/CmdCountdown.cs
@@ -25,7 +25,7 @@ using MCGalaxy.Generator;
 
 namespace MCGalaxy.Modules.Games.Countdown
 {    
-    public sealed class CmdCountdown : RoundsGameCmd 
+    sealed class CmdCountdown : RoundsGameCmd 
     {
         public override string name { get { return "CountDown"; } }
         public override string shortcut { get { return "CD"; } }

--- a/MCGalaxy/Modules/Games/TNTWars/CmdTntWars.cs
+++ b/MCGalaxy/Modules/Games/TNTWars/CmdTntWars.cs
@@ -25,7 +25,7 @@ using BlockID = System.UInt16;
 
 namespace MCGalaxy.Modules.Games.TW
 {
-    public sealed class CmdTntWars : RoundsGameCmd 
+    sealed class CmdTntWars : RoundsGameCmd 
     {
         public override string name { get { return "TntWars"; } }
         public override string shortcut { get { return "tw"; } }

--- a/MCGalaxy/Modules/Games/ZombieSurvival/ZSGame.DB.cs
+++ b/MCGalaxy/Modules/Games/ZombieSurvival/ZSGame.DB.cs
@@ -123,15 +123,15 @@ namespace MCGalaxy.Modules.Games.ZS
             ZSData data = TryGet(p);
             if (data == null || (data.TotalRoundsSurvived == 0 && data.TotalInfected == 0)) return;
             
-            int count = Database.CountRows("ZombieStats", "WHERE Name=@0", p.name);
-            if (count == 0) {
-                Database.AddRow("ZombieStats", "TotalRounds, MaxRounds, TotalInfected, MaxInfected, Name",
-                                data.TotalRoundsSurvived, data.MaxRoundsSurvived,
-                                data.TotalInfected,       data.MaxInfected, p.name);
-            } else {
-                Database.UpdateRows("ZombieStats", "TotalRounds=@0, MaxRounds=@1, TotalInfected=@2, MaxInfected=@3",
-                                    "WHERE Name=@4", data.TotalRoundsSurvived, data.MaxRoundsSurvived,
-                                                     data.TotalInfected,       data.MaxInfected, p.name);
+            object[] args = new object[] {
+                data.TotalRoundsSurvived, data.MaxRoundsSurvived, data.TotalInfected, data.MaxInfected,      
+                p.name
+            };
+            
+            int changed = Database.UpdateRows("ZombieStats", "TotalRounds=@0, MaxRounds=@1, TotalInfected=@2, MaxInfected=@3",
+                                              "WHERE Name=@4", args);
+            if (changed == 0) {
+                Database.AddRow("ZombieStats", "TotalRounds, MaxRounds, TotalInfected, MaxInfected, Name", args);
             }
         }
         

--- a/MCGalaxy/Modules/Games/ZombieSurvival/ZSGame.DB.cs
+++ b/MCGalaxy/Modules/Games/ZombieSurvival/ZSGame.DB.cs
@@ -124,14 +124,15 @@ namespace MCGalaxy.Modules.Games.ZS
             if (data == null || (data.TotalRoundsSurvived == 0 && data.TotalInfected == 0)) return;
             
             object[] args = new object[] {
-                data.TotalRoundsSurvived, data.MaxRoundsSurvived, data.TotalInfected, data.MaxInfected,      
+                data.TotalRoundsSurvived, data.MaxRoundsSurvived, 
+                data.TotalInfected, data.MaxInfected,
                 p.name
             };
             
-            int changed = Database.UpdateRows("ZombieStats", "TotalRounds=@0, MaxRounds=@1, TotalInfected=@2, MaxInfected=@3",
+            int changed = Database.UpdateRows("ZombieStats", "TotalRounds=@0,MaxRounds=@1, TotalInfected=@2,MaxInfected=@3",
                                               "WHERE Name=@4", args);
             if (changed == 0) {
-                Database.AddRow("ZombieStats", "TotalRounds, MaxRounds, TotalInfected, MaxInfected, Name", args);
+                Database.AddRow("ZombieStats", "TotalRounds,MaxRounds, TotalInfected,MaxInfected, Name", args);
             }
         }
         


### PR DESCRIPTION
* Changed the `modifier` argument to be required
This prevents accidentally forgetting to set a modifier, which would result in that by default all rows in the table would get updated/deleted (usually not desired)

* Changed the return value to be the number of rows updated/deleted
1. Allows seeing how many rows were updated/deleted by the SQL command
2. Allows optimising the `if (rows_potentially_affected() > 0) { update_rows() } else { add_row() }` pattern to `if (update_rows() == 0) { add_row() }`