### PR TITLE
Allow OPs to ignore 'Lately known as...' messages

### DIFF
--- a/MCGalaxy/Commands/Chat/CmdIgnore.cs
+++ b/MCGalaxy/Commands/Chat/CmdIgnore.cs
@@ -53,6 +53,8 @@ namespace MCGalaxy.Commands.Chatting
                 Toggle(p, ref p.Ignores.DrawOutput, "{0} ignoring draw command output"); return;
             } else if (action == "worldchanges") {
                 Toggle(p, ref p.Ignores.WorldChanges, "{0} ignoring world changes"); return;
+            } else if (action == "altlogins") {
+                Toggle(p, ref p.Ignores.AltLogins, "{0} ignoring alt accounts messages when a player joins"); return;
             } else if (IsListAction(action)) {
                 p.Ignores.Output(p); return;
             }
@@ -115,6 +117,7 @@ namespace MCGalaxy.Commands.Chatting
             p.Message("&H 8ball - &T/8ball &His ignored.");
             p.Message("&H drawoutput - drawing command output is ignored.");
             p.Message("&H worldchanges - world change messages are ignored.");  
+            p.Message("&H altlogins - login messages showing alt accounts are ignored.");
         }
     }
 }

--- a/MCGalaxy/Player/Player.Login.cs
+++ b/MCGalaxy/Player/Player.Login.cs
@@ -264,7 +264,7 @@ namespace MCGalaxy
             string altsMsg = "λNICK &Sis lately known as: " + alts.Join();
 
             Chat.MessageFrom(p, altsMsg,
-                             (pl, obj) => pl.CanSee(p) && opchat.UsableBy(pl));
+                             (pl, obj) => pl.CanSee(p) && opchat.UsableBy(pl) && !pl.Ignores.AltLogins);
                          
             //IRCBot.Say(temp, true); //Tells people in op channel on IRC
             altsMsg = altsMsg.Replace("λNICK", name);

--- a/MCGalaxy/Player/PlayerIgnores.cs
+++ b/MCGalaxy/Player/PlayerIgnores.cs
@@ -23,7 +23,7 @@ namespace MCGalaxy {
     
     public class PlayerIgnores {
         public List<string> Names = new List<string>(), IRCNicks = new List<string>();
-        public bool All, IRC, Titles, Nicks, EightBall, DrawOutput, WorldChanges;
+        public bool All, IRC, Titles, Nicks, EightBall, DrawOutput, WorldChanges, AltLogins;
         
         public void Load(Player p) {
             string path = "ranks/ignore/" + p.name + ".txt";
@@ -42,6 +42,7 @@ namespace MCGalaxy {
                     if (line == "&8ball") { EightBall = true; continue; }
                     if (line == "&drawoutput") { DrawOutput = true; continue; }
                     if (line == "&worldchanges") { WorldChanges = true; continue; }
+                    if (line == "&altlogins") { AltLogins = true; continue; }
                     
                     if (line.StartsWith("&irc_")) {
                         IRCNicks.Add(line.Substring("&irc_".Length));
@@ -53,7 +54,7 @@ namespace MCGalaxy {
                 Logger.LogError("Error loading ignores for " + p.name, ex);
             }
             
-            bool special = All || IRC || Titles || Nicks || EightBall || DrawOutput || WorldChanges;
+            bool special = All || IRC || Titles || Nicks || EightBall || DrawOutput || WorldChanges || AltLogins;
             if (special || Names.Count > 0 || IRCNicks.Count > 0) {
                 p.Message("&cType &a/ignore list &cto see who you are still ignoring");
             }
@@ -75,6 +76,7 @@ namespace MCGalaxy {
                     if (EightBall) w.WriteLine("&8ball");                    
                     if (DrawOutput) w.WriteLine("&drawoutput");
                     if (WorldChanges) w.WriteLine("&worldchanges");
+                    if (AltLogins) w.WriteLine("&altlogins");
                     
                     foreach (string nick in IRCNicks) { w.WriteLine("&irc_" + nick); }
                     foreach (string name in Names) { w.WriteLine(name); }
@@ -103,6 +105,7 @@ namespace MCGalaxy {
             if (EightBall) p.Message("&cIgnoring &T/8ball");            
             if (DrawOutput) p.Message("&cIgnoring draw command output");           
             if (WorldChanges) p.Message("&cIgnoring world change messages");
+            if (AltLogins) p.Message("&cPlayer alt accounts do not show when they join");
         }
     }
 }


### PR DESCRIPTION
Added a field to ignore `Lately known as...` messages.

It is useful notably when recording/livestreaming to avoid leaking alts. Also reduces chat spam when a player has lots of alts/when there are many logins.