### PR TITLE
Fix ZS Stats Bug

### DIFF
--- a/MCGalaxy/Modules/Games/ZombieSurvival/ZSGame.DB.cs
+++ b/MCGalaxy/Modules/Games/ZombieSurvival/ZSGame.DB.cs
@@ -36,9 +36,9 @@ namespace MCGalaxy.Modules.Games.ZS
         static void HookStats() {
             statMostInfected = new DBTopStat("Infected", "Most players infected",
                                              "ZombieStats", "TotalInfected", TopStat.FormatInteger);
-            statMaxInfected  = new DBTopStat("Survived", "Most rounds survived",
+            statMostSurvived = new DBTopStat("Survived", "Most rounds survived",
                                              "ZombieStats", "TotalRounds",   TopStat.FormatInteger);
-            statMostSurvived = new DBTopStat("ConsecutiveInfected", "Most consecutive infections",
+            statMaxInfected = new DBTopStat("ConsecutiveInfected", "Most consecutive infections",
                                              "ZombieStats", "MaxInfected",   TopStat.FormatInteger);
             statMaxSurvived  = new DBTopStat("ConsecutiveSurvived", "Most consecutive rounds survived", 
                                              "ZombieStats", "MaxRounds",     TopStat.FormatInteger);


### PR DESCRIPTION
statMostSurvived and statMostInfected now point to the appropriate ZombieStats DB column.