### PR TITLE
Add Custom presence to the Discord presence activity enum

### DIFF
--- a/MCGalaxy/Modules/Relay/Discord/DiscordPlugin.cs
+++ b/MCGalaxy/Modules/Relay/Discord/DiscordPlugin.cs
@@ -87,7 +87,7 @@ namespace MCGalaxy.Modules.Relay.Discord
     }
     
     public enum PresenceStatus { online, dnd, idle, invisible }
-    public enum PresenceActivity { Playing = 0, Listening = 2, Watching = 3, Competing = 5 }
+    public enum PresenceActivity { Playing = 0, Listening = 2, Watching = 3, Custom = 4, Competing = 5 }
     
     public sealed class DiscordPlugin : Plugin 
     {


### PR DESCRIPTION
Bots can use the Custom presence option for statuses now. This change makes it so it is possible to use the Custom presence type for the Discord bridge.