### PR TITLE
Implement AmpersandSupport CPE extension

### DIFF
--- a/MCGalaxy/Network/CPESupport.cs
+++ b/MCGalaxy/Network/CPESupport.cs
@@ -96,6 +96,7 @@ namespace MCGalaxy
         public const string CinematicGui = "CinematicGui";
         public const string NotifyAction = "NotifyAction";
         public const string ToggleBlockList = "ToggleBlockList";
+        public const string AmpersandSupport = "AmpersandSupport";
     }
     
     public sealed class CpeExtension 
@@ -158,6 +159,7 @@ namespace MCGalaxy
             new CpeExtension(CpeExt.LightingMode,        "Allows changing how the client lights worlds"),
             new CpeExtension(CpeExt.CinematicGui,        "Allows changing the visibility of some GUI components"),
             new CpeExtension(CpeExt.NotifyAction,        "Allows server to be notified of certain client events"),
+            new CpeExtension(CpeExt.AmpersandSupport,    "Allows literal '&' in chat messages without escaping to '%'"),
             #if TEN_BIT_BLOCKS
             new CpeExtension(CpeExt.ExtBlocks,           "Allows using block IDs over 255 in block definitions"),
             #endif

--- a/MCGalaxy/Network/ClassicProtocol.cs
+++ b/MCGalaxy/Network/ClassicProtocol.cs
@@ -26,7 +26,7 @@ namespace MCGalaxy.Network
     {
         // these are checked very frequently, so avoid overhead of .Supports(
         bool hasEmoteFix, hasTwoWayPing, hasExtTexs, hasTextColors;
-        bool hasHeldBlock, hasLongerMessages;
+        bool hasHeldBlock, hasLongerMessages, hasAmpersand;
         
         bool finishedCpeLogin;
         int extensionCount;
@@ -354,6 +354,8 @@ namespace MCGalaxy.Network
                 hasHeldBlock = true;
             } else if (ext.Name == CpeExt.LongerMessages) {
                 hasLongerMessages = true;
+            } else if (ext.Name == CpeExt.AmpersandSupport) {
+                hasAmpersand = true;
             }
             #if TEN_BIT_BLOCKS
             else if (ext.Name == CpeExt.ExtBlocks) {
@@ -433,8 +435,8 @@ namespace MCGalaxy.Network
         public override void SendChat(string message) {
             int bufferLen;
             // See comment in CleanupColors
-            char[] buffer = LineWrapper.CleanupColors(message, out bufferLen, 
-                                                      hasTextColors, hasTextColors);
+            char[] buffer = LineWrapper.CleanupColors(message, out bufferLen,
+                                                      hasAmpersand || hasTextColors, hasTextColors);
             List<string> lines = LineWrapper.Wordwrap(buffer, bufferLen, hasEmoteFix);
 
             // Need to combine chat line packets into one Send call, so that
@@ -731,7 +733,7 @@ namespace MCGalaxy.Network
             // Since it's impossible to identify which client is being used,
             //  just remove the ampersands to be on the safe side
             //  when text colours extension is not supported
-            return LineWrapper.CleanupColors(value, hasTextColors, hasTextColors);
+            return LineWrapper.CleanupColors(value, hasAmpersand || hasTextColors, hasTextColors);
         }
 
         public override string ClientName() {


### PR DESCRIPTION
Client-side implementation: ClassiCube/ClassiCube#1559

Without this extension, clients escape literal `&` to `%` before sending chat, corrupting messages like `hello every & one` and URL parameters like `&utm_source=x`. With the extension negotiated, the client sends `&` literally and the server preserves it end-to-end.


URLs can still be corrupted in a few cases due to the line wrapper treating `&X` as color codes:

- consecutive color codes are deduplicated (`&a&b` → `&b`), so e.g. `?x=&a&b=1` loses the `&a` param
- a `&f` split across a wordwrap boundary eats the following character (`&fancy=value` at line end → `ancy=value` on the next line)
- leading spaces on wrapped continuation lines are trimmed
- trailing color codes are stripped from the end of a line (`/?a=b&c` → `/?a=b`)
